### PR TITLE
feat: SuccessResponse 및 전역적 예외처리 구현

### DIFF
--- a/src/main/java/konkuk/kuit/durimong/global/exception/CustomException.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/CustomException.java
@@ -1,0 +1,30 @@
+package konkuk.kuit.durimong.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private Exception originException;
+    private final ErrorCode errorCode;
+    private final String message;
+    private final String additionalInfo;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+        this.additionalInfo = null;
+    }
+
+    public CustomException(ErrorCode errorCode, String additionalMessage) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+        this.additionalInfo = additionalMessage;
+    }
+
+    public CustomException(ErrorCode errorCode, Exception exception) {
+        this.errorCode = errorCode;
+        this.originException = exception;
+        this.message = errorCode.getMessage();
+        this.additionalInfo = null;
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -1,0 +1,30 @@
+package konkuk.kuit.durimong.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+    //사용자 정의 ErrorCode로, 발생할 수 있는 예외들을 사용자 정의로 선언하시면 됩니다. 엔티티 별로 추가해주시면 됩니다.
+    //Common
+    SERVER_UNTRACKED_ERROR(-100, "미등록 서버 에러입니다. 서버 팀에 연락주세요.", 500),
+    OBJECT_NOT_FOUND(-101, "조회된 객체가 없습니다.", 406),
+    INVALID_PARAMETER(-102, "잘못된 파라미터입니다.", 422),
+    PARAMETER_VALIDATION_ERROR(-103, "파라미터 검증 에러입니다.", 422),
+    PARAMETER_GRAMMAR_ERROR(-104, "파라미터 문법 에러입니다.", 422),
+    INVALID_TYPE_PARAMETER(-106, "잘못된 타입 파라미터입니다.", 422),
+    NOT_FOUND_PATH(-108, "존재하지 않는 API 경로입니다.", 404),
+
+    //User
+    USER_NOT_FOUND(-300, "존재하지 않는 회원입니다.", 406),
+    USER_DUPLICATE_ID(-301, "이미 존재하는 아이디입니다.", 401),
+    USER_NOT_MATCH_PASSWORD(-302, "비밀번호가 일치하지 않습니다.", 403);
+    //Mong
+
+
+
+    private final int errorCode;
+    private final String message;
+    private final int httpCode;
+}

--- a/src/main/java/konkuk/kuit/durimong/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,130 @@
+package konkuk.kuit.durimong.global.exception;
+
+import konkuk.kuit.durimong.global.response.ErrorResponse;
+import konkuk.kuit.durimong.global.response.result.ParameterData;
+import konkuk.kuit.durimong.global.response.result.ServerErrorData;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static konkuk.kuit.durimong.global.exception.ErrorCode.NOT_FOUND_PATH;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    /**
+     * 등록되지 않은 예외
+     */
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    protected ErrorResponse<ServerErrorData> handleUntrackedException(Exception e) {
+        log.error("[UNTRACKED ERROR] class: [{}], message: [{}]",
+                e.getClass().getSimpleName(),
+                e.getMessage());
+
+        ServerErrorData serverErrorData = ServerErrorData.builder()
+                .errorClass(e.getClass().toString())
+                .errorMessage(e.getMessage())
+                .build();
+        return ErrorResponse.of(ErrorCode.SERVER_UNTRACKED_ERROR, serverErrorData);
+    }
+
+    /**
+     * 파라미터 검증 예외
+     */
+    @ExceptionHandler({MethodArgumentNotValidException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ErrorResponse<List<ParameterData>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        log.warn("[PARAMETER VALIDATION EXCEPTION] class: [{}], message: [{}], localizedMessage: [{}]",
+                e.getClass().getSimpleName(),
+                e.getMessage(),
+                e.getLocalizedMessage());
+
+        List<ParameterData> list = new ArrayList<>();
+
+        BindingResult bindingResult = e.getBindingResult();
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            ParameterData parameterData = ParameterData.builder()
+                    .key(fieldError.getField())
+                    .value(fieldError.getRejectedValue() == null ? null : fieldError.getRejectedValue().toString())
+                    .reason(fieldError.getDefaultMessage())
+                    .build();
+            list.add(parameterData);
+        }
+
+        return ErrorResponse.of(ErrorCode.PARAMETER_VALIDATION_ERROR, list);
+    }
+
+    /**
+     * 파라미터 문법 예외
+     */
+    @ExceptionHandler({HttpMessageNotReadableException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ErrorResponse<String> handleHttpMessageParsingExceptions(HttpMessageNotReadableException e) {
+        log.warn("[PARAMETER GRAMMAR EXCEPTION] class: [{}], message: [{}]",
+                e.getClass().getSimpleName(),
+                e.getMessage());
+
+        return ErrorResponse.of(ErrorCode.PARAMETER_GRAMMAR_ERROR);
+    }
+
+    /**
+     * 매개변수 타입 예외
+     */
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    public ErrorResponse<String> handleHttpMessageParsingExceptions(MethodArgumentTypeMismatchException e) {
+        log.warn("[METHOD ARGUMENT TYPE EXCEPTION] class: [{}], message: [{}]",
+                e.getClass().getSimpleName(),
+                e.getMessage());
+
+        return ErrorResponse.of(ErrorCode.INVALID_PARAMETER, e.getMessage());
+    }
+
+    /**
+     * 커스텀 예외
+     */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse<Object>> handleCustomExceptions(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        if (e.getOriginException() != null) {
+            log.error("[ORIGIN ERROR] class: [{}], message: [{}], localizedMessage: [{}]",
+                    e.getOriginException().getClass().getSimpleName(),
+                    e.getOriginException().getMessage(),
+                    e.getOriginException().getLocalizedMessage());
+        }
+        log.warn("[CUSTOM EXCEPTION] class: [{}], message: [{}]",
+                e.getClass().getSimpleName(),
+                errorCode.getMessage());
+
+        ErrorResponse<Object> body = ErrorResponse.of(errorCode, e.getAdditionalInfo());
+        HttpStatus httpStatus = HttpStatus.valueOf(errorCode.getHttpCode());
+        return new ResponseEntity<>(body, httpStatus);
+    }
+
+    /**
+     * 경로 존재하지 않음
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ErrorResponse<String>> handleInvalidPathExceptions(NoHandlerFoundException e) {
+        ErrorResponse<String> body = ErrorResponse.of(NOT_FOUND_PATH, e.getMessage());
+        HttpStatus httpStatus = HttpStatus.valueOf(NOT_FOUND_PATH.getHttpCode());
+        return new ResponseEntity<>(body, httpStatus);
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/global/response/ErrorResponse.java
+++ b/src/main/java/konkuk/kuit/durimong/global/response/ErrorResponse.java
@@ -1,0 +1,46 @@
+package konkuk.kuit.durimong.global.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.kuit.durimong.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ErrorResponse<T> {
+    @Schema(description = "성공 여부", nullable = false, example = "false")
+    private boolean success = false;
+
+    @Schema(description = "예외 코드", nullable = false, example = "-100")
+    private int code;
+
+    @Schema(description = "예외 메세지", nullable = false, example = "예외 메세지")
+    private String message;
+
+    @Schema(description = "예외 참고 데이터", nullable = false)
+    private T result;
+
+    public ErrorResponse(int code, String message, T result) {
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+
+    public static <T> ErrorResponse<T> of(int code, String message) {
+        return new ErrorResponse<>(code, message, null);
+    }
+
+    public static <T> ErrorResponse<T> of(ErrorCode errorCode) {
+        return new ErrorResponse<>(errorCode.getErrorCode(), errorCode.getMessage(), null);
+    }
+
+    public static <T> ErrorResponse<T> of(int code, String message, T data) {
+        return new ErrorResponse<>(code, message, data);
+    }
+
+    public static <T> ErrorResponse<T> of(ErrorCode errorCode, T data) {
+        return new ErrorResponse<>(errorCode.getErrorCode(), errorCode.getMessage(), data);
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/global/response/SuccessResponse.java
+++ b/src/main/java/konkuk/kuit/durimong/global/response/SuccessResponse.java
@@ -1,0 +1,34 @@
+package konkuk.kuit.durimong.global.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class SuccessResponse<T> {
+    @Schema(description = "성공 여부", nullable = false, example = "true")
+    private boolean success = true;
+
+    @Schema(description = "상태 코드", nullable = false, example = "1")
+    private int code;
+
+    @Schema(description = "응답 메세지", nullable = false, example = "성공하였습니다.")
+    private String message;
+
+    @Schema(description = "응답 데이터", nullable = false)
+    private T result;
+
+    public SuccessResponse(int code, String message, T result) {
+        this.code = code;
+        this.message = message;
+        this.result = result;
+    }
+
+    public static <T> SuccessResponse<T> of(int code, String message, T data) {
+        return new SuccessResponse<>(code, message, data);
+    }
+
+}

--- a/src/main/java/konkuk/kuit/durimong/global/response/SuccessResponse.java
+++ b/src/main/java/konkuk/kuit/durimong/global/response/SuccessResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
+import konkuk.kuit.durimong.global.response.result.ResponseState;
 @Getter
 @Setter
 @ToString
@@ -29,6 +29,10 @@ public class SuccessResponse<T> {
 
     public static <T> SuccessResponse<T> of(int code, String message, T data) {
         return new SuccessResponse<>(code, message, data);
+    }
+
+    public static <T> SuccessResponse<T> ok(T data) {
+        return of(ResponseState.SUCCESS.getCode(), ResponseState.SUCCESS.getMessage(), data);
     }
 
 }

--- a/src/main/java/konkuk/kuit/durimong/global/response/result/ParameterData.java
+++ b/src/main/java/konkuk/kuit/durimong/global/response/result/ParameterData.java
@@ -1,0 +1,16 @@
+package konkuk.kuit.durimong.global.response.result;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class ParameterData {
+    private String key;
+    private String value;
+    private String reason;
+}

--- a/src/main/java/konkuk/kuit/durimong/global/response/result/ResponseState.java
+++ b/src/main/java/konkuk/kuit/durimong/global/response/result/ResponseState.java
@@ -1,0 +1,14 @@
+package konkuk.kuit.durimong.global.response.result;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ResponseState {
+    SUCCESS(1, "성공하였습니다."),
+    FAIL(-1, "실패하였습니다.");
+
+    private int code;
+    private String message;
+}

--- a/src/main/java/konkuk/kuit/durimong/global/response/result/ServerErrorData.java
+++ b/src/main/java/konkuk/kuit/durimong/global/response/result/ServerErrorData.java
@@ -1,0 +1,15 @@
+package konkuk.kuit.durimong.global.response.result;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@ToString
+public class ServerErrorData {
+    private String errorClass;
+    private String errorMessage;
+}


### PR DESCRIPTION
## 📝작업 내용
SuccessResponse 클래스는 Controller 내 각 메서드에서 반환타입으로 사용됩니다. 제네릭 타입으로 선언하여 기능마다 구현된 DTO를 담아서 
응답 시 반환합니다.  public SuccessResponse<UserTokenRes> signup 이런 식으로 메서드 선언하시면 됩니다. 
GlobalExceptionHandler를 구현하여 전역적으로 Controller들의 예외들을 처리할 수 있게 만들었습니다. 
비즈니스 로직을 구현하시다가 예외가 터질 만한 상황이 있으면 ErrorCode에 해당 예외 추가해주시고, throw new CustomException(ErrorCode.USER_NOT_FOUND)와 같이 예외 처리 해주시면 됩니다. 


## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
