### PR TITLE
Feat: 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,14 +36,12 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-	implementation 'javax.mail:javax.mail-api:1.6.2'
-	implementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5") // JJWT (JSON Web Token) API
 	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5") // JJWT 구현 라이브러리
 	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5") // JJWT Jackson 지원 라이브러리
-	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
+	implementation 'com.github.kstyrc:embedded-redis:0.6'
 
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5") // JJWT (JSON Web Token) API

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package konkuk.kuit.durimong.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import konkuk.kuit.durimong.domain.user.dto.request.login.ReIssueTokenReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.*;
+import konkuk.kuit.durimong.domain.user.dto.response.ReIssueTokenRes;
 import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
 import konkuk.kuit.durimong.domain.user.service.UserService;
 import konkuk.kuit.durimong.global.response.SuccessResponse;
@@ -58,5 +60,13 @@ public class UserController {
     public SuccessResponse<UserTokenRes> login(
             @Validated @RequestBody UserLoginReq req){
         return SuccessResponse.ok(userService.login(req));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "토큰 유효기간 만료 시 호출되는 API입니다.")
+    @PostMapping("newtokens")
+    public SuccessResponse<ReIssueTokenRes> reIssueTokens(
+            @Validated @RequestBody ReIssueTokenReq req
+    ){
+        return SuccessResponse.ok(userService.reissueToken(req));
     }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -7,10 +7,13 @@ import konkuk.kuit.durimong.domain.user.dto.request.signup.*;
 import konkuk.kuit.durimong.domain.user.dto.response.ReIssueTokenRes;
 import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
 import konkuk.kuit.durimong.domain.user.service.UserService;
+import konkuk.kuit.durimong.global.annotation.CustomExceptionDescription;
 import konkuk.kuit.durimong.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -19,18 +22,21 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "아이디 중복검사", description = "아이디 중복여부를 확인합니다.")
+    @CustomExceptionDescription(USER_ID)
     @PostMapping("userid")
     public SuccessResponse<String> getId(UserIdReq req){
         return SuccessResponse.ok(userService.validateId(req.getId()));
     }
 
     @Operation(summary = "이메일 중복검사", description = "이메일 중복여부를 확인합니다.")
+    @CustomExceptionDescription(USER_EMAIL)
     @PostMapping("email")
     public SuccessResponse<String> getEmail(UserEmailReq req){
         return SuccessResponse.ok(userService.validateEmail(req.getEmail()));
     }
 
     @Operation(summary = "비밀번호 유효성 검사", description = "비밀번호의 유효성(길이,영문 + 숫자)을 검사합니다.")
+    @CustomExceptionDescription(USER_PASSWORD)
     @PostMapping("password")
     public SuccessResponse<String> getPassword(UserPasswordReq req){
         return SuccessResponse.ok(userService.validatePassword(req.getPassword()));
@@ -43,12 +49,14 @@ public class UserController {
     }
 
     @Operation(summary = "이메일 인증번호 확인", description = "유저에게 전송한 인증번호와 유저가 입력한 인증번호 일치 여부를 확인합니다.")
+    @CustomExceptionDescription(USER_EMAIL_VERIFICATION)
     @GetMapping("email-verifications")
     public SuccessResponse<String> emailVerification(EmailVerifyReq req){
         return SuccessResponse.ok(userService.verifyCode(req.getEmail(),req.getAuthCode()));
     }
 
     @Operation(summary = "회원가입",description = "유저가 회원가입을 합니다.")
+    @CustomExceptionDescription(USER_SIGNUP)
     @PostMapping("signup")
     public SuccessResponse<String> signup(
             @Validated @RequestBody UserSignUpReq req){
@@ -56,6 +64,7 @@ public class UserController {
     }
 
     @Operation(summary = "로그인", description = "유저가 로그인을 합니다.")
+    @CustomExceptionDescription(USER_LOGIN)
     @PostMapping("login")
     public SuccessResponse<UserTokenRes> login(
             @Validated @RequestBody UserLoginReq req){
@@ -63,6 +72,7 @@ public class UserController {
     }
 
     @Operation(summary = "토큰 재발급", description = "토큰 유효기간 만료 시 호출되는 API입니다.")
+    @CustomExceptionDescription(REISSUE_TOKEN)
     @PostMapping("newtokens")
     public SuccessResponse<ReIssueTokenRes> reIssueTokens(
             @Validated @RequestBody ReIssueTokenReq req

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -1,7 +1,9 @@
 package konkuk.kuit.durimong.domain.user.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.*;
+import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
 import konkuk.kuit.durimong.domain.user.service.UserService;
 import konkuk.kuit.durimong.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -50,5 +52,11 @@ public class UserController {
             @Validated @RequestBody UserSignUpReq req){
         return SuccessResponse.ok(userService.register(req));
     }
-    
+
+    @Operation(summary = "로그인", description = "유저가 로그인을 합니다.")
+    @PostMapping("login")
+    public SuccessResponse<UserTokenRes> login(
+            @Validated @RequestBody UserLoginReq req){
+        return SuccessResponse.ok(userService.login(req));
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/login/ReIssueTokenReq.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/login/ReIssueTokenReq.java
@@ -1,0 +1,10 @@
+package konkuk.kuit.durimong.domain.user.dto.request.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ReIssueTokenReq {
+    @Schema(description = "Refresh Token")
+    private String refreshToken;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/login/UserLoginReq.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/login/UserLoginReq.java
@@ -1,0 +1,13 @@
+package konkuk.kuit.durimong.domain.user.dto.request.login;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class UserLoginReq {
+    @Schema(description = "아이디", example ="durymong")
+    private String id;
+
+    @Schema(description = "비밀번호", example = "durymong123")
+    private String password;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/ReIssueTokenRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/ReIssueTokenRes.java
@@ -1,0 +1,15 @@
+package konkuk.kuit.durimong.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ReIssueTokenRes {
+    @Schema(description = "새 Access Token")
+    private String newAccessToken;
+
+    @Schema(description = "새 Refresh Token")
+    private String newRefreshToken;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserTokenRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserTokenRes.java
@@ -12,4 +12,7 @@ public class UserTokenRes {
 
     @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
     private String accessToken;
+
+    @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+    private String refreshToken;
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserTokenRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserTokenRes.java
@@ -1,4 +1,4 @@
-package konkuk.kuit.durimong.domain.user.dto.response.signup;
+package konkuk.kuit.durimong.domain.user.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/konkuk/kuit/durimong/domain/user/entity/User.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/entity/User.java
@@ -2,16 +2,14 @@ package konkuk.kuit.durimong.domain.user.entity;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserRepository.java
@@ -8,7 +8,9 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsById(String id);
+    boolean findByuserId(long userId);
     boolean existsByEmail(String email);
     User save(User user);
     Optional<User> findById(String id);
+    Optional<User> findByUserId(Long userId);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserRepository.java
@@ -3,9 +3,12 @@ package konkuk.kuit.durimong.domain.user.repository;
 import konkuk.kuit.durimong.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsById(String id);
     boolean existsByEmail(String email);
 
+    Optional<User> findById(String id);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserRepository.java
@@ -9,6 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsById(String id);
     boolean existsByEmail(String email);
-
+    User save(User user);
     Optional<User> findById(String id);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/MailService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/MailService.java
@@ -17,15 +17,13 @@ import static konkuk.kuit.durimong.global.exception.ErrorCode.UNABLE_TO_SEND_EMA
 public class MailService {
     private final JavaMailSender emailSender;
 
-    public void sendEmail(String toEmail,
-                          String title,
-                          String text) {
+    public void sendEmail(String toEmail, String title, String text) {
         SimpleMailMessage emailForm = createEmailForm(toEmail, title, text);
         try {
+            log.info("Sending email to {}", toEmail);
             emailSender.send(emailForm);
         } catch (RuntimeException e) {
-            log.debug("MailService.sendEmail exception occur toEmail: {}, " +
-                    "title: {}, text: {}", toEmail, title, text);
+            log.error("Failed to send email: {}", e.getMessage(), e);
             throw new CustomException(UNABLE_TO_SEND_EMAIL);
         }
     }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Random;
 
 import static konkuk.kuit.durimong.global.exception.ErrorCode.*;
@@ -106,6 +107,8 @@ public class UserService {
         if (!req.getPassword().equals(user.getPassword())) {
             throw new CustomException(USER_NOT_MATCH_PASSWORD);
         }
+        user.setLastLogin(LocalDateTime.now());
+        userRepository.save(user);
         String accessToken = jwtProvider.createAccessToken(user);
         return new UserTokenRes(accessToken);
     }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -125,14 +125,11 @@ public class UserService {
             throw new CustomException(JWT_EXPIRE_TOKEN);
         }
         Long userId = jwtProvider.getUserIdFromRefreshToken(refreshToken);
-        log.info("Checking if refresh token exists for userId in Redis: {}", userId);
         if(!jwtProvider.checkTokenExists(String.valueOf(userId))) {
-            log.error("Refresh token not found in Redis for userId: {}", userId);
             throw new CustomException(BAD_REQUEST);
         }
         jwtProvider.invalidateToken(userId);
 
-        log.info("Attempting to find user with userId: {}", userId);
         User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         String newAccessToken = jwtProvider.createAccessToken(user);
         String newRefreshToken = jwtProvider.createRefreshToken(user);

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -1,7 +1,9 @@
 package konkuk.kuit.durimong.domain.user.service;
 
 import jakarta.transaction.Transactional;
+import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.UserSignUpReq;
+import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
 import konkuk.kuit.durimong.domain.user.entity.User;
 import konkuk.kuit.durimong.domain.user.repository.UserRepository;
 import konkuk.kuit.durimong.global.exception.CustomException;
@@ -98,6 +100,15 @@ public class UserService {
         return "회원가입이 완료되었습니다.";
     }
 
+    public UserTokenRes login(UserLoginReq req){
+        User user = userRepository.findById(req.getId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        if (!req.getPassword().equals(user.getPassword())) {
+            throw new CustomException(USER_NOT_MATCH_PASSWORD);
+        }
+        String accessToken = jwtProvider.createAccessToken(user);
+        return new UserTokenRes(accessToken);
+    }
 
 
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -96,8 +96,7 @@ public class UserService {
 
     public String register(UserSignUpReq req) {
         User user = User.create(req.getId(), req.getPassword(), req.getEmail(),req.getName(),req.getEmail());
-        user = userRepository.save(user);
-        String accessToken = jwtProvider.createAccessToken(user);
+        userRepository.save(user);
         return "회원가입이 완료되었습니다.";
     }
 
@@ -110,7 +109,9 @@ public class UserService {
         user.setLastLogin(LocalDateTime.now());
         userRepository.save(user);
         String accessToken = jwtProvider.createAccessToken(user);
-        return new UserTokenRes(accessToken);
+        String refreshToken = jwtProvider.createRefreshToken(user);
+        jwtProvider.storeRefreshToken(refreshToken,user.getUserId());
+        return new UserTokenRes(accessToken,refreshToken);
     }
 
 

--- a/src/main/java/konkuk/kuit/durimong/global/annotation/CustomExceptionDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/annotation/CustomExceptionDescription.java
@@ -1,0 +1,15 @@
+package konkuk.kuit.durimong.global.annotation;
+
+import konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CustomExceptionDescription {
+
+    SwaggerResponseDescription value();
+}

--- a/src/main/java/konkuk/kuit/durimong/global/annotation/LoginArgumentResolver.java
+++ b/src/main/java/konkuk/kuit/durimong/global/annotation/LoginArgumentResolver.java
@@ -1,0 +1,46 @@
+package konkuk.kuit.durimong.global.annotation;
+
+import konkuk.kuit.durimong.global.exception.CustomException;
+import konkuk.kuit.durimong.global.exception.ErrorCode;
+import konkuk.kuit.durimong.global.jwt.JwtTokenAuthentication;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class) &&
+                parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        validateAuthentication(authentication);
+
+        return getUserIdxFromAuthentication(authentication);
+    }
+
+    private void validateAuthentication(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    private Long getUserIdxFromAuthentication(Authentication authentication) {
+        if (!(authentication instanceof JwtTokenAuthentication)) {
+            throw new CustomException(ErrorCode.AUTHENTICATION_SETTING_FAIL);
+        }
+        return ((JwtTokenAuthentication) authentication).getUserId();
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/global/annotation/UserId.java
+++ b/src/main/java/konkuk/kuit/durimong/global/annotation/UserId.java
@@ -1,0 +1,12 @@
+package konkuk.kuit.durimong.global.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/konkuk/kuit/durimong/global/config/EmailConfig.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/EmailConfig.java
@@ -1,5 +1,6 @@
 package konkuk.kuit.durimong.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,7 @@ import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 import java.util.Properties;
 
+@Slf4j
 @Configuration
 public class EmailConfig {
     @Value("${spring.mail.host}")

--- a/src/main/java/konkuk/kuit/durimong/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -56,10 +55,12 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .authorizeHttpRequests((authorizeRequests) ->
                         authorizeRequests
-                                .requestMatchers(HttpMethod.POST, PUBLIC_POST).permitAll()
-                                .requestMatchers(HttpMethod.GET, PUBLIC_GET).permitAll()
-                                .requestMatchers(HttpMethod.PUT, PUBLIC_PUT).permitAll()
-                                .anyRequest().authenticated()
+                                .anyRequest().permitAll() //테스트할 때 일일히 인증하기 귀찮으니까.. 일단 다 열어둠
+//                                .requestMatchers(HttpMethod.POST, PUBLIC_POST).permitAll()
+//                                .requestMatchers(HttpMethod.GET, PUBLIC_GET).permitAll()
+//                                .requestMatchers(HttpMethod.PUT, PUBLIC_PUT).permitAll()
+//                                .anyRequest().authenticated()
+
                 );
         http
                 .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/konkuk/kuit/durimong/global/config/SwaggerConfig.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/SwaggerConfig.java
@@ -5,8 +5,31 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import konkuk.kuit.durimong.global.annotation.CustomExceptionDescription;
+import konkuk.kuit.durimong.global.config.swagger.ExampleHolder;
+import konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription;
+import konkuk.kuit.durimong.global.exception.ErrorCode;
+import konkuk.kuit.durimong.global.response.ErrorResponse;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
 
 @OpenAPIDefinition(
         servers = @Server(url = "/", description = "Default Server URL"),
@@ -18,10 +41,104 @@ import org.springframework.context.annotation.Configuration;
 )
 @Configuration
 public class SwaggerConfig {
+    private final String securitySchemaName = "JWT";
+
     @Bean
-    public OpenAPI openAPI() {
+    public OpenAPI customOpenAPI() {
         return new OpenAPI()
-                .components(new Components());
+                .components(setComponents())
+                .addSecurityItem(setSecurityItems());
+    }
+    private Components setComponents() {
+        return new Components()
+                .addSecuritySchemes(securitySchemaName, bearerAuth());
+    }
+
+    private SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("Bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+
+    private SecurityRequirement setSecurityItems() {
+        return new SecurityRequirement()
+                .addList(securitySchemaName);
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+
+            CustomExceptionDescription customExceptionDescription = handlerMethod.getMethodAnnotation(
+                    CustomExceptionDescription.class);
+
+            // CustomExceptionDescription 어노테이션 단 메소드 적용
+            if (customExceptionDescription != null) {
+                generateErrorCodeResponseExample(operation, customExceptionDescription.value());
+            }
+
+            return operation;
+        };
+    }
+
+    private void generateErrorCodeResponseExample(
+            Operation operation, SwaggerResponseDescription type) {
+
+        ApiResponses responses = operation.getResponses();
+
+        Set<ErrorCode> errorCodeList = type.getErrorCodeList();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                errorCodeList.stream()
+                        .map(
+                                errorCode -> {
+                                    return ExampleHolder.builder()
+                                            .holder(
+                                                    getSwaggerExample(errorCode))
+                                            .code(errorCode.getHttpCode())
+                                            .name(errorCode.toString())
+                                            .build();
+                                }
+                        ).collect(groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        Map<String, String> result = new LinkedHashMap<>();
+
+        if (errorCode.getErrorCode() == ErrorCode.PARAMETER_VALIDATION_ERROR.getErrorCode()) {
+            result.put("key", "검증 대상 파라미터");
+            result.put("value", "받은 파라미터 값");
+            result.put("reason", "검증 에러 원인 메세지");
+        }
+
+        ErrorResponse errorResponse = new ErrorResponse(errorCode.getErrorCode(), errorCode.getMessage(), result);
+        Example example = new Example();
+        example.description(errorCode.getMessage());
+        example.setValue(errorResponse);
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> {
+                                mediaType.addExamples(
+                                        exampleHolder.getName(), exampleHolder.getHolder());
+                            });
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setDescription("");
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
     }
 
 }

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/ExampleHolder.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package konkuk.kuit.durimong.global.config.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -1,0 +1,54 @@
+package konkuk.kuit.durimong.global.config.swagger;
+
+
+import konkuk.kuit.durimong.global.exception.ErrorCode;
+import lombok.Getter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+@Getter
+public enum SwaggerResponseDescription {
+
+    USER_SIGNUP(new LinkedHashSet<>(Set.of(
+            ErrorCode.USER_DUPLICATE_ID,
+            ErrorCode.USER_DUPLICATE_EMAIL,
+            ErrorCode.USER_PASSWORD_ENGLISH,
+            ErrorCode.USER_PASSWORD_SHORT,
+            ErrorCode.USER_PASSWORD_NONUM,
+            ErrorCode.USER_EMAIL_VERIFY_FAILED
+    ))),
+    USER_LOGIN(new LinkedHashSet<>(Set.of(
+            ErrorCode.USER_NOT_MATCH_PASSWORD
+    ))),
+    USER_MYPAGE(new LinkedHashSet<>(Set.of())),
+    REISSUE_TOKEN(new LinkedHashSet<>(Set.of(
+            ErrorCode.USER_NOT_FOUND
+    )))
+    ;
+
+
+    private Set<ErrorCode> errorCodeList;
+
+    SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
+        // 공통 에러
+        errorCodeList.addAll(new LinkedHashSet<>(Set.of(
+                ErrorCode.SERVER_UNTRACKED_ERROR,
+                ErrorCode.INVALID_PARAMETER,
+                ErrorCode.PARAMETER_VALIDATION_ERROR,
+                ErrorCode.PARAMETER_GRAMMAR_ERROR,
+                ErrorCode.UNAUTHORIZED,
+                ErrorCode.FORBIDDEN,
+                ErrorCode.JWT_ERROR_TOKEN,
+                ErrorCode.JWT_EXPIRE_TOKEN,
+                ErrorCode.AUTHORIZED_ERROR,
+                ErrorCode.OBJECT_NOT_FOUND
+        )));
+
+        if (this.name().contains("USER_")) {
+            errorCodeList.add(ErrorCode.USER_NOT_FOUND);
+        }
+
+        this.errorCodeList = errorCodeList;
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -7,25 +7,40 @@ import lombok.Getter;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import static konkuk.kuit.durimong.global.exception.ErrorCode.*;
+
 @Getter
 public enum SwaggerResponseDescription {
 
+    //User
     USER_SIGNUP(new LinkedHashSet<>(Set.of(
-            ErrorCode.USER_DUPLICATE_ID,
-            ErrorCode.USER_DUPLICATE_EMAIL,
-            ErrorCode.USER_PASSWORD_ENGLISH,
-            ErrorCode.USER_PASSWORD_SHORT,
-            ErrorCode.USER_PASSWORD_NONUM,
-            ErrorCode.USER_EMAIL_VERIFY_FAILED
+            USER_DUPLICATE_ID
+    ))),
+    USER_ID(new LinkedHashSet<>(Set.of(
+            USER_DUPLICATE_ID
+    ))),
+    USER_PASSWORD(new LinkedHashSet<>(Set.of(
+            USER_PASSWORD_ENGLISH,
+            USER_PASSWORD_SHORT,
+            USER_PASSWORD_NONUM
+    ))),
+    USER_EMAIL(new LinkedHashSet<>(Set.of(
+            USER_DUPLICATE_EMAIL
     ))),
     USER_LOGIN(new LinkedHashSet<>(Set.of(
-            ErrorCode.USER_NOT_MATCH_PASSWORD
+            USER_NOT_MATCH_PASSWORD,
+            USER_NOT_FOUND
+    ))),
+    USER_EMAIL_VERIFICATION(new LinkedHashSet<>(Set.of(
+            USER_EMAIL_VERIFY_FAILED
     ))),
     USER_MYPAGE(new LinkedHashSet<>(Set.of())),
     REISSUE_TOKEN(new LinkedHashSet<>(Set.of(
-            ErrorCode.USER_NOT_FOUND
-    )))
-    ;
+            USER_NOT_FOUND,
+            JWT_EXPIRE_TOKEN,
+            JWT_ERROR_TOKEN,
+            BAD_REQUEST
+    )));
 
 
     private Set<ErrorCode> errorCodeList;
@@ -33,20 +48,20 @@ public enum SwaggerResponseDescription {
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
         // 공통 에러
         errorCodeList.addAll(new LinkedHashSet<>(Set.of(
-                ErrorCode.SERVER_UNTRACKED_ERROR,
-                ErrorCode.INVALID_PARAMETER,
-                ErrorCode.PARAMETER_VALIDATION_ERROR,
-                ErrorCode.PARAMETER_GRAMMAR_ERROR,
-                ErrorCode.UNAUTHORIZED,
-                ErrorCode.FORBIDDEN,
-                ErrorCode.JWT_ERROR_TOKEN,
-                ErrorCode.JWT_EXPIRE_TOKEN,
-                ErrorCode.AUTHORIZED_ERROR,
-                ErrorCode.OBJECT_NOT_FOUND
+                SERVER_UNTRACKED_ERROR,
+                INVALID_PARAMETER,
+                PARAMETER_VALIDATION_ERROR,
+                PARAMETER_GRAMMAR_ERROR,
+                UNAUTHORIZED,
+                FORBIDDEN,
+                JWT_ERROR_TOKEN,
+                JWT_EXPIRE_TOKEN,
+                AUTHORIZED_ERROR,
+                OBJECT_NOT_FOUND
         )));
 
         if (this.name().contains("USER_")) {
-            errorCodeList.add(ErrorCode.USER_NOT_FOUND);
+            errorCodeList.add(USER_NOT_FOUND);
         }
 
         this.errorCodeList = errorCodeList;

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     NOT_FOUND_PATH(-108, "존재하지 않는 API 경로입니다.", 404),
     UNABLE_TO_SEND_EMAIL(-109,"이메일을 전송할 수 없습니다.",404),
     NO_SUCH_ALGORITHM(-110,"사용 불가능한 암호화 알고리즘입니다.",404),
+    BAD_REQUEST(-111,"로그아웃된 사용자입니다.",406),
     //Auth
     UNAUTHORIZED(-200, "인증 자격이 없습니다.", 401),
     FORBIDDEN(-201, "권한이 없습니다.", 403),
@@ -24,6 +25,9 @@ public enum ErrorCode {
     JWT_EXPIRE_TOKEN(-203, "만료된 토큰입니다.", 401),
     AUTHORIZED_ERROR(-204, "인증 과정 중 에러가 발생했습니다.", 500),
     AUTHENTICATION_SETTING_FAIL(-207, "인증정보 처리에 실패했습니다.", 500),
+    INVALID_TOKEN(-208,"저장된 토큰과 일치하지 않습니다.",404),
+    NOT_FOUND_AVAILABLE_PORT(-209,"이용 가능한 포트를 찾지 못했습니다.",406),
+    ERROR_EXECUTING_EMBEDDED_REDIS(-210,"REDIS 서버 실행 중 오류가 발생했습니다.",406),
     //User
     USER_NOT_FOUND(-300, "존재하지 않는 회원입니다.", 406),
     USER_DUPLICATE_ID(-301, "이미 존재하는 아이디입니다.", 401),

--- a/src/main/java/konkuk/kuit/durimong/global/jwt/JwtProvider.java
+++ b/src/main/java/konkuk/kuit/durimong/global/jwt/JwtProvider.java
@@ -71,9 +71,7 @@ public class JwtProvider {
     }
 
     public Long getUserIdFromRefreshToken(String refreshToken) {
-        log.info("Refresh token: {}", refreshToken);
         Claims claims = getClaims(refreshToken);
-        log.info("Extracted userId from refreshToken: {}", claims.get("userId"));
         if (!"refresh".equals(claims.get("category"))) {
             throw new CustomException(ErrorCode.JWT_ERROR_TOKEN); // 적절한 에러 코드 설정
         }
@@ -88,26 +86,18 @@ public class JwtProvider {
                     .build()
                     .parseClaimsJws(token)
                     .getBody();
-
-            // 만료시간 확인
             Date expiration = claims.getExpiration();
             if (expiration.before(new Date())) {
-                log.debug("Refresh Token이 만료되었습니다.");
                 throw new CustomException(ErrorCode.JWT_EXPIRE_TOKEN);
             }
-
-            // Refresh Token의 카테고리 확인 (선택적으로 사용 가능)
             if (!"refresh".equals(claims.get("category"))) {
-                log.debug("유효하지 않은 Refresh Token입니다.");
                 throw new CustomException(ErrorCode.JWT_ERROR_TOKEN);
             }
 
-            return true; // 유효한 토큰
+            return true;
         } catch (ExpiredJwtException e) {
-            log.debug("만료된 Refresh Token입니다.");
             throw new CustomException(ErrorCode.JWT_EXPIRE_TOKEN);
         } catch (JwtException | IllegalArgumentException e) {
-            log.debug("유효하지 않은 Refresh Token입니다.");
             throw new CustomException(ErrorCode.JWT_ERROR_TOKEN);
         }
     }

--- a/src/main/java/konkuk/kuit/durimong/global/jwt/JwtTokenAuthentication.java
+++ b/src/main/java/konkuk/kuit/durimong/global/jwt/JwtTokenAuthentication.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 public class JwtTokenAuthentication implements Authentication {
 
-    private final Long usIdx;
+    private final Long userId;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,9 +125,9 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
-    auth-code-expiration-millis: 1800000  # 30 * 60 * 1000 == 30?
+    auth-code-expiration-millis: 1800000
 
 jwt:
   secret: ${JWT_SECRET}
-  accessTokenExpiration: 3600000 #1??
+  accessTokenExpiration: 3600000
   refreshTokenExpiration: 604800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,3 +130,4 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   accessTokenExpiration: 3600000 #1??
+  refreshTokenExpiration: 604800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     active: dev
 
 ---
-# ??? DB
+# 로컬용 DB
 spring:
   config:
     activate:
@@ -36,7 +36,7 @@ spring:
       port: 6379
 
 ---
-# ??? DB
+# 개발용 DB
 spring:
   config:
     activate:
@@ -61,7 +61,7 @@ spring:
       port: 6379
 
 ---
-# ??? DB
+# 배포용 DB
 spring:
   config:
     activate:
@@ -86,7 +86,7 @@ spring:
       port: 6379
 
 ---
-# ??? ??
+# 개발용 포트
 spring:
   config:
     activate:
@@ -94,7 +94,7 @@ spring:
 server:
   port: 9001
 ---
-# ??? ??
+# 배포용 포트
 spring:
   config:
     activate:
@@ -102,7 +102,7 @@ spring:
 server:
   port: 9002
 ---
-# ??
+# 공통
 spring:
   config:
     activate:


### PR DESCRIPTION
## 📝작업 내용
로그인 기능을 구현하였습니다. 로그인 시 Access Token과 Refresh Token이 발급되며, redis 서버에 refresh Token을 저장하고, 유효기간 만료 시 재발급됩니다. 
LoginArgumentResolver를 구현하여 로그인되어 있는 사용자의 userId를 @UserId 어노테이션을 통해 쉽게 가져올 수 있도록 구현했습니다.

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
