### PR TITLE
Feat: 로그아웃 기능, 일일 질문 로직 수정

### DIFF
--- a/src/main/java/konkuk/kuit/durimong/domain/mong/entity/MongQuestion.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/mong/entity/MongQuestion.java
@@ -15,12 +15,9 @@ import lombok.NoArgsConstructor;
 public class MongQuestion {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long mongAnswerId;
+    private Long mongQuestionId;
 
     @Schema(nullable = false)
     private String question;
 
-    @ManyToOne
-    @JoinColumn(name = "MongId")
-    private Mong mong;
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/mong/repository/MongQuestionRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/mong/repository/MongQuestionRepository.java
@@ -2,9 +2,16 @@ package konkuk.kuit.durimong.domain.mong.repository;
 
 import konkuk.kuit.durimong.domain.mong.entity.MongQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
+
 
 public interface MongQuestionRepository extends JpaRepository<MongQuestion, Long> {
     List<MongQuestion> findAll();
+
+
+    @Query("SELECT m.question FROM MongQuestion m WHERE m.mongQuestionId = :date")
+    Optional<String> findQuestionByDate(int date);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -90,4 +90,16 @@ public class UserController {
             @Parameter(hidden = true) @UserId Long userId){
         return SuccessResponse.ok(userService.homePage(userId));
     }
+
+    @Operation(summary = "로그아웃", description = "유저가 로그아웃을 합니다.")
+    @CustomExceptionDescription(USER_LOGOUT)
+    @PostMapping("logout")
+    public SuccessResponse<String> logout(
+            @Parameter(hidden = true) @RequestHeader(value = "Authorization",required = false) String token,
+            @Parameter(hidden = true) @UserId Long userId){
+
+        String accessToken = token.replace("Bearer ", "");
+        return SuccessResponse.ok(userService.logout(accessToken,userId));
+    }
+
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -26,7 +26,6 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
@@ -157,7 +156,7 @@ public class UserService {
         String mongName = findMong.getName();
         LocalDateTime createdAt = findMong.getCreatedAt();
         int dateWithMong = getDateWithMong(today,createdAt);
-        String mongQuestion = getMongQuestion(findMong,userId);
+        String mongQuestion = getDailyQuestion(userId);
 
         return new UserHomeRes(todayDate, dateWithMong, mongName, mongImage, mongQuestion);
     }
@@ -166,20 +165,17 @@ public class UserService {
         return (int) Duration.between(createdAt, today).toDays() + 1;
     }
 
-    private String getMongQuestion(Mong mong, @UserId Long userId){
+    private String getDailyQuestion(@UserId Long userId){
         List<MongQuestion> mongAnswers = mongAnswerRepository.findAll();
-        List<MongQuestion> realAnswers = new ArrayList<>();
-        for (MongQuestion mongAnswer : mongAnswers) {
-            if(mongAnswer.getMong().getUser().getUserId().equals(userId)){
-                realAnswers.add(mongAnswer);
-            }
-        }
-        int size = realAnswers.size();
-        if(size == 0){
+        if(mongAnswers.isEmpty()){
             throw new CustomException(QUESTION_NOT_EXISTS);
         }
-        Random random = new Random();
-        return mongAnswers.get(random.nextInt(size)).getQuestion();
+        LocalDate today = LocalDate.now();
+        int date = today.getDayOfMonth();
+        return mongAnswerRepository.findQuestionByDate(date).orElseThrow(
+                () -> new CustomException(QUESTION_NOT_EXISTS)
+        );
+
     }
 
     public String logout(String accessToken, Long userId){

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -182,6 +182,24 @@ public class UserService {
         return mongAnswers.get(random.nextInt(size)).getQuestion();
     }
 
+    public String logout(String accessToken, Long userId){
+        if(accessToken == null) {
+            throw new CustomException(USER_LOGOUTED);
+        }
+        long accessTokenExpirationMillis = jwtProvider.getClaims(accessToken).getExpiration().getTime() - System.currentTimeMillis();
+        if (accessTokenExpirationMillis > 0) {
+            redisService.setValues("BLACKLIST:" + accessToken, "logout", Duration.ofMillis(accessTokenExpirationMillis));
+        }
+
+        if (jwtProvider.checkTokenExists(String.valueOf(userId))) {
+            jwtProvider.invalidateToken(userId);
+        }
+
+        log.info("User {} has logged out.", userId);
+        return "로그아웃이 완료되었습니다.";
+    }
+
+
 
 
 

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -46,6 +46,10 @@ public enum SwaggerResponseDescription {
             MONG_NOT_FOUND,
             QUESTION_NOT_EXISTS
     ))),
+    USER_LOGOUT(new LinkedHashSet<>(Set.of(
+            JWT_LOGOUT_TOKEN,
+            USER_LOGOUTED
+    ))),
 
     //Mong
     MONG_NAME(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
     INVALID_TOKEN(-208,"저장된 토큰과 일치하지 않습니다.",404),
     NOT_FOUND_AVAILABLE_PORT(-209,"이용 가능한 포트를 찾지 못했습니다.",406),
     ERROR_EXECUTING_EMBEDDED_REDIS(-210,"REDIS 서버 실행 중 오류가 발생했습니다.",406),
+    JWT_LOGOUT_TOKEN(-211,"로그아웃된 토큰입니다.",406),
     //User
     USER_NOT_FOUND(-300, "존재하지 않는 회원입니다.", 406),
     USER_DUPLICATE_ID(-301, "이미 존재하는 아이디입니다.", 401),
@@ -37,6 +38,7 @@ public enum ErrorCode {
     USER_PASSWORD_NONUM(-305,"비밀번호에 숫자가 포함되어야 합니다.",401),
     USER_PASSWORD_ENGLISH(-306,"비밀번호에 영문자가 포함되어야 합니다.",401),
     USER_EMAIL_VERIFY_FAILED(-307,"이메일 인증에 실패하였씁니다.",401),
+    USER_LOGOUTED(-308,"로그아웃 되어 있는 상태입니다.",401),
     //Mong
     MONG_NAME_LENGTH(-400,"이름은 1~6자로 입력해주세요.",401),
     MONG_NOT_FOUND(-401, "캐릭터를 생성하지 않았습니다.",406),

--- a/src/main/java/konkuk/kuit/durimong/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/konkuk/kuit/durimong/global/jwt/JwtAuthenticationFilter.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
-
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {


### PR DESCRIPTION
## 📝작업 내용
유저가 로그아웃하는 기능과, 원래는 질문 테이블에서 랜덤으로 질문을 가져오던 로직을 매일매일 다른 질문을 가져오도록, 질문의 개수가 31개이므로 현재 날짜와 질문 ID를 비교하여 질문을 가져오는 방식으로 구현했습니다.
## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
