### PR TITLE
Feat: 몽과 대화하기 기능 및 알림 설정 화면 구현

### DIFF
--- a/src/main/java/konkuk/kuit/durimong/domain/mong/repository/MongQuestionRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/mong/repository/MongQuestionRepository.java
@@ -10,8 +10,15 @@ import java.util.Optional;
 
 public interface MongQuestionRepository extends JpaRepository<MongQuestion, Long> {
     List<MongQuestion> findAll();
-
+    Optional<MongQuestion> findByQuestion(String question);
 
     @Query("SELECT m.question FROM MongQuestion m WHERE m.mongQuestionId = :date")
     Optional<String> findQuestionByDate(int date);
+
+    @Query("SELECT m FROM MongQuestion m WHERE m.mongQuestionId = :date")
+    Optional<MongQuestion> findMongQuestionByDate(int date);
+
+
+
+
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/mong/repository/MongQuestionRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/mong/repository/MongQuestionRepository.java
@@ -19,6 +19,4 @@ public interface MongQuestionRepository extends JpaRepository<MongQuestion, Long
     Optional<MongQuestion> findMongQuestionByDate(int date);
 
 
-
-
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -189,4 +189,13 @@ public class UserController {
     public SuccessResponse<String> deleteChat(@RequestBody @Validated UserDeleteChatReq req){
         return SuccessResponse.ok(userService.deleteChat(req));
     }
+
+    @Operation(summary = "알림 설정 화면",description = "알림 설정 화면 접속 시 호출되는 API입니다.")
+    @CustomExceptionDescription(USER_NOTIFICATION)
+    @GetMapping("notification")
+    public SuccessResponse<NotificationSettingFormRes> notificationSettingForm(
+            @Parameter(hidden = true) @UserId Long userId
+    ){
+        return SuccessResponse.ok(userService.notificationSettingForm(userId));
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package konkuk.kuit.durimong.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import konkuk.kuit.durimong.domain.user.dto.request.UserEditAnswerReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserEditPasswordReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserInfoReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
@@ -159,9 +160,21 @@ public class UserController {
     }
 
     @Operation(summary = "몽과의 대화", description = "유저가 몽의 질문에 답변을 작성합니다.")
+    @Tag(name = "Mong Conversation", description = "몽과의 대화 관련 API")
+    @CustomExceptionDescription(USER_ANSWER)
     @PostMapping("mong-conversation")
     public SuccessResponse<String> mongConversation(@RequestBody @Validated UserMongConversationReq req,
                                                     @Parameter(hidden = true) @UserId Long userId){
         return SuccessResponse.ok(userService.userAnswer(req,userId));
     }
+
+    @Operation(summary = "답변 다시하기", description = "유저가 몽의 질문에 했던 답변을 수정합니다.")
+    @Tag(name = "Mong Conversation", description = "몽과의 대화 관련 API")
+    @CustomExceptionDescription(USER_EDIT_ANSWER)
+    @PostMapping("answer-modification")
+    public SuccessResponse<String> answerModification(@RequestBody @Validated UserEditAnswerReq req,
+                                                      @Parameter(hidden = true) @UserId Long userId){
+        return SuccessResponse.ok(userService.editAnswer(req,userId));
+    }
+
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -10,10 +10,7 @@ import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.ReIssueTokenReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.*;
-import konkuk.kuit.durimong.domain.user.dto.response.ReIssueTokenRes;
-import konkuk.kuit.durimong.domain.user.dto.response.UserHomeRes;
-import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
-import konkuk.kuit.durimong.domain.user.dto.response.UserUnRegisterRes;
+import konkuk.kuit.durimong.domain.user.dto.response.*;
 import konkuk.kuit.durimong.domain.user.service.UserService;
 import konkuk.kuit.durimong.global.annotation.CustomExceptionDescription;
 import konkuk.kuit.durimong.global.annotation.UserId;
@@ -21,6 +18,8 @@ import konkuk.kuit.durimong.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.*;
 
@@ -176,5 +175,15 @@ public class UserController {
                                                       @Parameter(hidden = true) @UserId Long userId){
         return SuccessResponse.ok(userService.editAnswer(req,userId));
     }
+
+    @Operation(summary = "몽과의 대화 기록 보기", description = "몽과의 대화 기록을 조회합니다.")
+    @Tag(name = "Mong Conversation", description = "몽과의 대화 관련 API")
+    @CustomExceptionDescription(USER_CHAT_HISTORY)
+    @GetMapping("chat-history")
+    public SuccessResponse<List<UserChatHistoryRes>> showChatHistory(
+            @Parameter(hidden = true) @UserId Long userId){
+        return SuccessResponse.ok(userService.showChatHistory(userId));
+    }
+
 
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import konkuk.kuit.durimong.domain.user.dto.request.UserEditPasswordReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserInfoReq;
+import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.ReIssueTokenReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.*;
@@ -157,4 +158,10 @@ public class UserController {
         return SuccessResponse.ok(userService.unRegister(accessToken,userId));
     }
 
+    @Operation(summary = "몽과의 대화", description = "유저가 몽의 질문에 답변을 작성합니다.")
+    @PostMapping("mong-conversation")
+    public SuccessResponse<String> mongConversation(@RequestBody @Validated UserMongConversationReq req,
+                                                    @Parameter(hidden = true) @UserId Long userId){
+        return SuccessResponse.ok(userService.userAnswer(req,userId));
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/controller/UserController.java
@@ -3,10 +3,7 @@ package konkuk.kuit.durimong.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import konkuk.kuit.durimong.domain.user.dto.request.UserEditAnswerReq;
-import konkuk.kuit.durimong.domain.user.dto.request.UserEditPasswordReq;
-import konkuk.kuit.durimong.domain.user.dto.request.UserInfoReq;
-import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
+import konkuk.kuit.durimong.domain.user.dto.request.*;
 import konkuk.kuit.durimong.domain.user.dto.request.login.ReIssueTokenReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.*;
@@ -185,5 +182,11 @@ public class UserController {
         return SuccessResponse.ok(userService.showChatHistory(userId));
     }
 
-
+    @Operation(summary = "몽과의 대화 기록 삭제", description = "몽과의 대화 기록을 삭제합니다.")
+    @Tag(name = "Mong Conversation", description = "몽과의 대화 관련 API")
+    @CustomExceptionDescription(USER_DELETE_CHAT)
+    @PostMapping("conversation-elimination")
+    public SuccessResponse<String> deleteChat(@RequestBody @Validated UserDeleteChatReq req){
+        return SuccessResponse.ok(userService.deleteChat(req));
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/UserDeleteChatReq.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/UserDeleteChatReq.java
@@ -1,0 +1,10 @@
+package konkuk.kuit.durimong.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class UserDeleteChatReq {
+    @Schema(description = "삭제할 대화의 기본 키", example = "1")
+    private Long conversationId;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/UserEditAnswerReq.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/UserEditAnswerReq.java
@@ -1,0 +1,10 @@
+package konkuk.kuit.durimong.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class UserEditAnswerReq {
+    @Schema(description = "수정 답변", example = "아침에 샐러드를 먹었어.")
+    private String newAnswer;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/UserMongConversationReq.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/request/UserMongConversationReq.java
@@ -1,0 +1,10 @@
+package konkuk.kuit.durimong.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class UserMongConversationReq {
+    @Schema(description = "유저의 대답", example = "오늘은 토스트를 먹었어")
+    private String userAnswer;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/NotificationSettingFormRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/NotificationSettingFormRes.java
@@ -1,0 +1,15 @@
+package konkuk.kuit.durimong.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationSettingFormRes {
+    @Schema(description = "몽 이름", example = "두리몽")
+    private String mongName;
+
+    @Schema(description = "유저 닉네임", example = "엘리자베스")
+    private String userNickname;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserChatHistoryRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserChatHistoryRes.java
@@ -1,0 +1,22 @@
+package konkuk.kuit.durimong.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserChatHistoryRes {
+    @Schema(description = "대화 날짜", example = "2025/01/01")
+    private LocalDate createdAt;
+
+    @Schema(description = "몽의 질문", example = "좋아하는 장소가 어딘가요?")
+    private String mongQuestion;
+
+    @Schema(description = "유저의 답변", example = "건국대학교")
+    private String userAnswer;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserHomeRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/dto/response/UserHomeRes.java
@@ -24,4 +24,15 @@ public class UserHomeRes {
     @Schema(description = "몽 질문", example = "오늘 무엇을 먹었나요?")
     private String mongQuestion;
 
+    @Schema(description = "유저의 대답", example = "오늘 아침은 토스트")
+    private String userAnswer;
+
+
+    public UserHomeRes(LocalDate date, int withMongDate, String mongName, String mongImage, String mongQuestion) {
+        this.date = date;
+        this.withMongDate = withMongDate;
+        this.mongName = mongName;
+        this.mongImage = mongImage;
+        this.mongQuestion = mongQuestion;
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/entity/UserMongConversation.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/entity/UserMongConversation.java
@@ -1,0 +1,33 @@
+package konkuk.kuit.durimong.domain.user.entity;
+
+import jakarta.persistence.*;
+import konkuk.kuit.durimong.domain.mong.entity.MongQuestion;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserMongConversation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userMongConversationId;
+
+    @Column(nullable = false)
+    private String userAnswer;
+
+    @Column(nullable = false)
+    private LocalDate createdAt;
+
+    @OneToOne
+    @JoinColumn(name = "mongQuestionId")
+    private MongQuestion question;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/entity/UserMongConversation.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/entity/UserMongConversation.java
@@ -18,6 +18,9 @@ public class UserMongConversation {
     private Long userMongConversationId;
 
     @Column(nullable = false)
+    private String mongQuestion;
+
+    @Column(nullable = false)
     private String userAnswer;
 
     @Column(nullable = false)
@@ -31,11 +34,12 @@ public class UserMongConversation {
     @JoinColumn(name = "userId")
     private User user;
 
-    public static UserMongConversation create(String userAnswer, User user, MongQuestion question) {
+    public static UserMongConversation create(String userAnswer, User user, MongQuestion question, String mongQuestion) {
         return UserMongConversation.builder().
                 userAnswer(userAnswer).
                 createdAt(LocalDate.now()).
                 question(question).
+                mongQuestion(mongQuestion).
                 user(user).
                 build();
     }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/entity/UserMongConversation.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/entity/UserMongConversation.java
@@ -30,4 +30,13 @@ public class UserMongConversation {
     @ManyToOne
     @JoinColumn(name = "userId")
     private User user;
+
+    public static UserMongConversation create(String userAnswer, User user, MongQuestion question) {
+        return UserMongConversation.builder().
+                userAnswer(userAnswer).
+                createdAt(LocalDate.now()).
+                question(question).
+                user(user).
+                build();
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -1,0 +1,8 @@
+package konkuk.kuit.durimong.domain.user.repository;
+
+
+import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserMongConversationRepository extends JpaRepository<UserMongConversation, Long> {
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -1,9 +1,13 @@
 package konkuk.kuit.durimong.domain.user.repository;
 
 
+import konkuk.kuit.durimong.domain.mong.entity.MongQuestion;
+import konkuk.kuit.durimong.domain.user.entity.User;
 import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserMongConversationRepository extends JpaRepository<UserMongConversation, Long> {
     UserMongConversation save(UserMongConversation conversation);
+    UserMongConversation findByQuestion(MongQuestion mongQuestion);
+    UserMongConversation findByUserAndQuestion(User user, MongQuestion mongQuestion);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public interface UserMongConversationRepository extends JpaRepository<UserMongConversation, Long> {
     UserMongConversation save(UserMongConversation conversation);
-    Optional<UserMongConversation> findByUserAndQuestion(User user, MongQuestion mongQuestion);
+    UserMongConversation findByUserAndQuestion(User user, MongQuestion mongQuestion);
     Optional<UserMongConversation> findByCreatedAtAndUser(LocalDate createdAt, User user);
     @Query("SELECT new konkuk.kuit.durimong.domain.user.dto.response.UserChatHistoryRes(c.createdAt, c.mongQuestion, c.userAnswer) " +
             "FROM UserMongConversation c " +

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -5,4 +5,5 @@ import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserMongConversationRepository extends JpaRepository<UserMongConversation, Long> {
+    UserMongConversation save(UserMongConversation conversation);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -21,5 +21,5 @@ public interface UserMongConversationRepository extends JpaRepository<UserMongCo
             "WHERE c.user = :user " +
             "ORDER BY c.createdAt")
     List<UserChatHistoryRes> findAllByUser(User user);
-
+    Optional<UserMongConversation> findByUserMongConversationId(Long conversationId);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -2,15 +2,24 @@ package konkuk.kuit.durimong.domain.user.repository;
 
 
 import konkuk.kuit.durimong.domain.mong.entity.MongQuestion;
+import konkuk.kuit.durimong.domain.user.dto.response.UserChatHistoryRes;
 import konkuk.kuit.durimong.domain.user.entity.User;
 import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserMongConversationRepository extends JpaRepository<UserMongConversation, Long> {
     UserMongConversation save(UserMongConversation conversation);
     Optional<UserMongConversation> findByUserAndQuestion(User user, MongQuestion mongQuestion);
     Optional<UserMongConversation> findByCreatedAtAndUser(LocalDate createdAt, User user);
+    @Query("SELECT new konkuk.kuit.durimong.domain.user.dto.response.UserChatHistoryRes(c.createdAt, c.mongQuestion, c.userAnswer) " +
+            "FROM UserMongConversation c " +
+            "WHERE c.user = :user " +
+            "ORDER BY c.createdAt")
+    List<UserChatHistoryRes> findAllByUser(User user);
+
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/repository/UserMongConversationRepository.java
@@ -6,8 +6,11 @@ import konkuk.kuit.durimong.domain.user.entity.User;
 import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface UserMongConversationRepository extends JpaRepository<UserMongConversation, Long> {
     UserMongConversation save(UserMongConversation conversation);
-    UserMongConversation findByQuestion(MongQuestion mongQuestion);
-    UserMongConversation findByUserAndQuestion(User user, MongQuestion mongQuestion);
+    Optional<UserMongConversation> findByUserAndQuestion(User user, MongQuestion mongQuestion);
+    Optional<UserMongConversation> findByCreatedAtAndUser(LocalDate createdAt, User user);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -154,7 +154,6 @@ public class UserService {
         LocalDate todayDate = LocalDate.now();
         LocalDateTime today = LocalDateTime.now();
 
-        // 유저 및 몽 조회
         User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         Mong findMong = mongRepository.findByUser(user).orElseThrow(() -> new CustomException(MONG_NOT_FOUND));
         String mongImage = findMong.getImage();
@@ -162,16 +161,11 @@ public class UserService {
         LocalDateTime createdAt = findMong.getCreatedAt();
         int dateWithMong = getDateWithMong(today, createdAt);
 
-        // 오늘의 질문 조회
         String mongQuestion = getDailyQuestion();
         MongQuestion question = mongQuestionRepository.findMongQuestionByDate(todayDate.getDayOfMonth())
                 .orElseThrow(() -> new CustomException(QUESTION_NOT_EXISTS));
 
-        // 유저의 답변 조회
-        UserMongConversation conversation = userMongConversationRepository.findByUserAndQuestion(user, question).orElseThrow(
-                () -> new CustomException(CONVERSATION_NOT_EXISTS));
-
-        // 답변 여부에 따라 다른 Response 반환
+        UserMongConversation conversation = userMongConversationRepository.findByUserAndQuestion(user, question);
         if (conversation != null) {
             return new UserHomeRes(todayDate, dateWithMong, mongName, mongImage, mongQuestion, conversation.getUserAnswer());
         } else {
@@ -314,6 +308,11 @@ public class UserService {
         return "선택하신 대화가 삭제되었습니다.";
     }
 
+    public NotificationSettingFormRes notificationSettingForm(Long userId){
+        User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        Mong mong = mongRepository.findByUser(user).orElseThrow(() -> new CustomException(MONG_NOT_FOUND));
+        return new NotificationSettingFormRes(mong.getName(),user.getName());
+    }
 
 
 

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import konkuk.kuit.durimong.domain.mong.repository.MongQuestionRepository;
 import konkuk.kuit.durimong.domain.mong.repository.MongRepository;
 import konkuk.kuit.durimong.domain.user.dto.request.UserEditPasswordReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserInfoReq;
+import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.ReIssueTokenReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.UserSignUpReq;
@@ -15,6 +16,8 @@ import konkuk.kuit.durimong.domain.user.dto.response.UserHomeRes;
 import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
 import konkuk.kuit.durimong.domain.user.dto.response.UserUnRegisterRes;
 import konkuk.kuit.durimong.domain.user.entity.User;
+import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
+import konkuk.kuit.durimong.domain.user.repository.UserMongConversationRepository;
 import konkuk.kuit.durimong.domain.user.repository.UserRepository;
 import konkuk.kuit.durimong.global.annotation.UserId;
 import konkuk.kuit.durimong.global.exception.CustomException;
@@ -45,7 +48,9 @@ public class UserService {
     private final UserRepository userRepository;
     private final MongRepository mongRepository;
     private final MongQuestionRepository mongAnswerRepository;
+    private final UserMongConversationRepository userMongConversationRepository;
     private final JwtProvider jwtProvider;
+    private final MongQuestionRepository mongQuestionRepository;
     @Value("${spring.mail.auth-code-expiration-millis}")
     private long authCodeExpirationMillis;
 
@@ -160,6 +165,7 @@ public class UserService {
         LocalDateTime createdAt = findMong.getCreatedAt();
         int dateWithMong = getDateWithMong(today,createdAt);
         String mongQuestion = getDailyQuestion(userId);
+        
 
         return new UserHomeRes(todayDate, dateWithMong, mongName, mongImage, mongQuestion);
     }
@@ -251,6 +257,15 @@ public class UserService {
         userRepository.delete(user);
         userRepository.flush();
         return "회원 탈퇴가 완료되었습니다," ;
+    }
+
+    public String userAnswer(UserMongConversationReq req, Long userId){
+        User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        int date = LocalDate.now().getDayOfMonth();
+        MongQuestion question = mongQuestionRepository.findMongQuestionByDate(date).orElseThrow(() -> new CustomException(QUESTION_NOT_EXISTS));
+        UserMongConversation conv = UserMongConversation.create(req.getUserAnswer(),user,question);
+        userMongConversationRepository.save(conv);
+        return "답변 생성이 완료되었습니다.";
     }
 
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -253,9 +253,4 @@ public class UserService {
         return "회원 탈퇴가 완료되었습니다," ;
     }
 
-
-
-
-
-
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -5,17 +5,11 @@ import konkuk.kuit.durimong.domain.mong.entity.Mong;
 import konkuk.kuit.durimong.domain.mong.entity.MongQuestion;
 import konkuk.kuit.durimong.domain.mong.repository.MongQuestionRepository;
 import konkuk.kuit.durimong.domain.mong.repository.MongRepository;
-import konkuk.kuit.durimong.domain.user.dto.request.UserEditAnswerReq;
-import konkuk.kuit.durimong.domain.user.dto.request.UserEditPasswordReq;
-import konkuk.kuit.durimong.domain.user.dto.request.UserInfoReq;
-import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
+import konkuk.kuit.durimong.domain.user.dto.request.*;
 import konkuk.kuit.durimong.domain.user.dto.request.login.ReIssueTokenReq;
 import konkuk.kuit.durimong.domain.user.dto.request.login.UserLoginReq;
 import konkuk.kuit.durimong.domain.user.dto.request.signup.UserSignUpReq;
-import konkuk.kuit.durimong.domain.user.dto.response.ReIssueTokenRes;
-import konkuk.kuit.durimong.domain.user.dto.response.UserHomeRes;
-import konkuk.kuit.durimong.domain.user.dto.response.UserTokenRes;
-import konkuk.kuit.durimong.domain.user.dto.response.UserUnRegisterRes;
+import konkuk.kuit.durimong.domain.user.dto.response.*;
 import konkuk.kuit.durimong.domain.user.entity.User;
 import konkuk.kuit.durimong.domain.user.entity.UserMongConversation;
 import konkuk.kuit.durimong.domain.user.repository.UserMongConversationRepository;
@@ -279,7 +273,7 @@ public class UserService {
         User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
         int date = LocalDate.now().getDayOfMonth();
         MongQuestion question = mongQuestionRepository.findMongQuestionByDate(date).orElseThrow(() -> new CustomException(QUESTION_NOT_EXISTS));
-        UserMongConversation conv = UserMongConversation.create(req.getUserAnswer(),user,question);
+        UserMongConversation conv = UserMongConversation.create(req.getUserAnswer(),user,question,question.getQuestion());
         userMongConversationRepository.save(conv);
         return "답변 생성이 완료되었습니다.";
     }
@@ -305,6 +299,15 @@ public class UserService {
             jwtProvider.invalidateToken(userId);
         }
     }
+
+    public List<UserChatHistoryRes> showChatHistory(Long userId){
+        User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        return userMongConversationRepository.findAllByUser(user);
+    }
+
+    public String deleteChat(UserDeleteChatReq req){
+    }
+
 
 
 

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -306,6 +306,12 @@ public class UserService {
     }
 
     public String deleteChat(UserDeleteChatReq req){
+        UserMongConversation conversation = userMongConversationRepository.findByUserMongConversationId(req.getConversationId()).orElseThrow(
+                () -> new CustomException(CONVERSATION_NOT_EXISTS)
+        );
+        userMongConversationRepository.delete(conversation);
+        userMongConversationRepository.flush();
+        return "선택하신 대화가 삭제되었습니다.";
     }
 
 

--- a/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import konkuk.kuit.durimong.domain.mong.entity.Mong;
 import konkuk.kuit.durimong.domain.mong.entity.MongQuestion;
 import konkuk.kuit.durimong.domain.mong.repository.MongQuestionRepository;
 import konkuk.kuit.durimong.domain.mong.repository.MongRepository;
+import konkuk.kuit.durimong.domain.user.dto.request.UserEditAnswerReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserEditPasswordReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserInfoReq;
 import konkuk.kuit.durimong.domain.user.dto.request.UserMongConversationReq;
@@ -173,7 +174,8 @@ public class UserService {
                 .orElseThrow(() -> new CustomException(QUESTION_NOT_EXISTS));
 
         // 유저의 답변 조회
-        UserMongConversation conversation = userMongConversationRepository.findByUserAndQuestion(user, question);
+        UserMongConversation conversation = userMongConversationRepository.findByUserAndQuestion(user, question).orElseThrow(
+                () -> new CustomException(CONVERSATION_NOT_EXISTS));
 
         // 답변 여부에 따라 다른 Response 반환
         if (conversation != null) {
@@ -281,6 +283,16 @@ public class UserService {
         userMongConversationRepository.save(conv);
         return "답변 생성이 완료되었습니다.";
     }
+
+    public String editAnswer(UserEditAnswerReq req, Long userId){
+        User user = userRepository.findByUserId(userId).orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+        UserMongConversation conversation = userMongConversationRepository.findByCreatedAtAndUser(LocalDate.now(), user).orElseThrow(
+                () -> new CustomException(CONVERSATION_NOT_EXISTS));
+        conversation.setUserAnswer(req.getNewAnswer());
+        userMongConversationRepository.save(conversation);
+        return "답변 수정이 완료되었습니다.";
+    }
+
     private void invalidateTokens(String accessToken, Long userId) {
         if (accessToken != null) {
             long accessTokenExpirationMillis = jwtProvider.getClaims(accessToken).getExpiration().getTime() - System.currentTimeMillis();
@@ -293,6 +305,8 @@ public class UserService {
             jwtProvider.invalidateToken(userId);
         }
     }
+
+
 
 
 

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -71,6 +71,16 @@ public enum SwaggerResponseDescription {
     USER_ELIMINATE(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
     ))),
+    USER_ANSWER(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            CONVERSATION_NOT_EXISTS
+    ))),
+    USER_EDIT_ANSWER(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            CONVERSATION_NOT_EXISTS
+    ))),
+
+
 
     //Mong
     MONG_NAME(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -85,6 +85,10 @@ public enum SwaggerResponseDescription {
     USER_DELETE_CHAT(new LinkedHashSet<>(Set.of(
             CONVERSATION_NOT_EXISTS
     ))),
+    USER_NOTIFICATION(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            MONG_NOT_FOUND
+    ))),
 
     //Mong
     MONG_NAME(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -82,7 +82,9 @@ public enum SwaggerResponseDescription {
     USER_CHAT_HISTORY(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
     ))),
-
+    USER_DELETE_CHAT(new LinkedHashSet<>(Set.of(
+            CONVERSATION_NOT_EXISTS
+    ))),
 
     //Mong
     MONG_NAME(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -79,7 +79,9 @@ public enum SwaggerResponseDescription {
             USER_NOT_FOUND,
             CONVERSATION_NOT_EXISTS
     ))),
-
+    USER_CHAT_HISTORY(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
 
 
     //Mong

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -7,45 +7,54 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
     //사용자 정의 ErrorCode로, 발생할 수 있는 예외들을 사용자 정의로 선언하시면 됩니다. 엔티티 별로 추가해주시면 됩니다.
-    //Common
+    /*
+    400 (Bad Request): 잘못된 요청 (파라미터, 문법, 인증 정보 등)
+    401 (Unauthorized): 인증되지 않은 사용자
+    403 (Forbidden): 권한이 없는 사용자
+    404 (Not Found): 리소스나 경로가 존재하지 않는 경우
+    422 (Unprocessable Entity): 요청이 의미적으로 잘못되었을 때
+    500 (Internal Server Error): 서버에서 처리할 수 없는 예외 발생
+
+     */
+    // Common
     SERVER_UNTRACKED_ERROR(-100, "미등록 서버 에러입니다. 서버 팀에 연락주세요.", 500),
-    OBJECT_NOT_FOUND(-101, "조회된 객체가 없습니다.", 406),
-    INVALID_PARAMETER(-102, "잘못된 파라미터입니다.", 422),
-    PARAMETER_VALIDATION_ERROR(-103, "파라미터 검증 에러입니다.", 422),
-    PARAMETER_GRAMMAR_ERROR(-104, "파라미터 문법 에러입니다.", 422),
-    INVALID_TYPE_PARAMETER(-106, "잘못된 타입 파라미터입니다.", 422),
+    OBJECT_NOT_FOUND(-101, "조회된 객체가 없습니다.", 404),
+    INVALID_PARAMETER(-102, "잘못된 파라미터입니다.", 400),
+    PARAMETER_VALIDATION_ERROR(-103, "파라미터 검증 에러입니다.", 400),
+    PARAMETER_GRAMMAR_ERROR(-104, "파라미터 문법 에러입니다.", 400),
+    INVALID_TYPE_PARAMETER(-106, "잘못된 타입 파라미터입니다.", 400),
     NOT_FOUND_PATH(-108, "존재하지 않는 API 경로입니다.", 404),
-    UNABLE_TO_SEND_EMAIL(-109,"이메일을 전송할 수 없습니다.",404),
-    NO_SUCH_ALGORITHM(-110,"사용 불가능한 암호화 알고리즘입니다.",404),
-    BAD_REQUEST(-111,"로그아웃된 사용자입니다.",406),
-    //Auth
+    UNABLE_TO_SEND_EMAIL(-109,"이메일을 전송할 수 없습니다.", 500),
+    NO_SUCH_ALGORITHM(-110,"사용 불가능한 암호화 알고리즘입니다.", 500),
+    BAD_REQUEST(-111,"로그아웃된 사용자입니다.", 400),
+    // Auth
     UNAUTHORIZED(-200, "인증 자격이 없습니다.", 401),
     FORBIDDEN(-201, "권한이 없습니다.", 403),
     JWT_ERROR_TOKEN(-202, "잘못된 토큰입니다.", 401),
     JWT_EXPIRE_TOKEN(-203, "만료된 토큰입니다.", 401),
     AUTHORIZED_ERROR(-204, "인증 과정 중 에러가 발생했습니다.", 500),
     AUTHENTICATION_SETTING_FAIL(-207, "인증정보 처리에 실패했습니다.", 500),
-    INVALID_TOKEN(-208,"저장된 토큰과 일치하지 않습니다.",404),
-    NOT_FOUND_AVAILABLE_PORT(-209,"이용 가능한 포트를 찾지 못했습니다.",406),
-    ERROR_EXECUTING_EMBEDDED_REDIS(-210,"REDIS 서버 실행 중 오류가 발생했습니다.",406),
-    JWT_LOGOUT_TOKEN(-211,"로그아웃된 토큰입니다.",406),
-    //User
-    USER_NOT_FOUND(-300, "존재하지 않는 회원입니다.", 406),
-    USER_DUPLICATE_ID(-301, "이미 존재하는 아이디입니다.", 401),
+    INVALID_TOKEN(-208,"저장된 토큰과 일치하지 않습니다.", 401),
+    NOT_FOUND_AVAILABLE_PORT(-209,"이용 가능한 포트를 찾지 못했습니다.", 500),
+    ERROR_EXECUTING_EMBEDDED_REDIS(-210,"REDIS 서버 실행 중 오류가 발생했습니다.", 500),
+    JWT_LOGOUT_TOKEN(-211,"로그아웃된 토큰입니다.", 401),
+    // User
+    USER_NOT_FOUND(-300, "존재하지 않는 회원입니다.", 404),
+    USER_DUPLICATE_ID(-301, "이미 존재하는 아이디입니다.", 409),
     USER_NOT_MATCH_PASSWORD(-302, "비밀번호가 일치하지 않습니다.", 403),
-    USER_DUPLICATE_EMAIL(-303,"이미 사용중인 이메일입니다.",401),
-    USER_PASSWORD_SHORT(-304,"비밀번호는 6자 이상 10자 이하입니다.", 401),
-    USER_PASSWORD_NONUM(-305,"비밀번호에 숫자가 포함되어야 합니다.",401),
-    USER_PASSWORD_ENGLISH(-306,"비밀번호에 영문자가 포함되어야 합니다.",401),
-    USER_EMAIL_VERIFY_FAILED(-307,"이메일 인증에 실패하였습니다.",401),
-    USER_LOGOUTED(-308,"로그아웃 되어 있는 상태입니다.",401),
-    USER_SAME_NAME(-309,"현재 사용자의 이름과 수정하시려는 이름이 일치합니다.",406),
-    USER_SAME_PASSWORD(-310,"현재 비밀번호와 새 비밀번호가 일치합니다.",406),
-    //Mong
-    MONG_NAME_LENGTH(-400,"이름은 1~6자로 입력해주세요.",401),
-    MONG_NOT_FOUND(-401, "캐릭터를 생성하지 않았습니다.",406),
-    QUESTION_NOT_EXISTS(-402, "등록된 몽의 질문이 없습니다.",406),
-    MONG_SAME_NAME(-403,"현재 몽의 이름과 수정하시려는 몽의 이름이 일치합니다.",406);
+    USER_DUPLICATE_EMAIL(-303,"이미 사용중인 이메일입니다.", 409),
+    USER_PASSWORD_SHORT(-304,"비밀번호는 6자 이상 10자 이하입니다.", 400),
+    USER_PASSWORD_NONUM(-305,"비밀번호에 숫자가 포함되어야 합니다.", 400),
+    USER_PASSWORD_ENGLISH(-306,"비밀번호에 영문자가 포함되어야 합니다.", 400),
+    USER_EMAIL_VERIFY_FAILED(-307,"이메일 인증에 실패하였습니다.", 400),
+    USER_LOGOUTED(-308,"로그아웃 되어 있는 상태입니다.", 401),
+    USER_SAME_NAME(-309,"현재 사용자의 이름과 수정하시려는 이름이 일치합니다.", 400),
+    USER_SAME_PASSWORD(-310,"현재 비밀번호와 새 비밀번호가 일치합니다.", 400),
+    // Mong
+    MONG_NAME_LENGTH(-400,"이름은 1~6자로 입력해주세요.", 400),
+    MONG_NOT_FOUND(-401, "캐릭터를 생성하지 않았습니다.", 404),
+    QUESTION_NOT_EXISTS(-402, "등록된 몽의 질문이 없습니다.", 404),
+    MONG_SAME_NAME(-403,"현재 몽의 이름과 수정하시려는 몽의 이름이 일치합니다.", 400);
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -54,8 +54,9 @@ public enum ErrorCode {
     MONG_NAME_LENGTH(-400,"이름은 1~6자로 입력해주세요.", 400),
     MONG_NOT_FOUND(-401, "캐릭터를 생성하지 않았습니다.", 404),
     QUESTION_NOT_EXISTS(-402, "등록된 몽의 질문이 없습니다.", 404),
-    MONG_SAME_NAME(-403,"현재 몽의 이름과 수정하시려는 몽의 이름이 일치합니다.", 400);
-
+    MONG_SAME_NAME(-403,"현재 몽의 이름과 수정하시려는 몽의 이름이 일치합니다.", 400),
+    //UserMongConversation
+    CONVERSATION_NOT_EXISTS(-500,"몽과의 대화가 존재하지 않습니다,",404);
     private final int errorCode;
     private final String message;
     private final int httpCode;


### PR DESCRIPTION
## 📝작업 내용
몽의 질문에 대답을 하고, 대답한 것을 수정하는 기능, 대화 기록을 조회하는 기능, 대회 기록을 삭제하는 기능과 알림 설정 화면에서 유저의 닉네임과 몽의 이름이 필요하여 그 부분에 대한 API까지 구현하였습니다.
## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
