### PR TITLE
Feat: 칼럼 카테고리 상세정보 조회 / 키워드 검색 / 칼럼 조회 기능 구현

### DIFF
--- a/src/main/java/konkuk/kuit/durimong/domain/column/controller/ColumnController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/controller/ColumnController.java
@@ -1,9 +1,11 @@
 package konkuk.kuit.durimong.domain.column.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import konkuk.kuit.durimong.domain.column.dto.response.CategoryDetailRes;
 import konkuk.kuit.durimong.domain.column.dto.response.CategoryRes;
 import konkuk.kuit.durimong.domain.column.dto.response.ColumnRes;
+import konkuk.kuit.durimong.domain.column.dto.response.KeywordSearchRes;
 import konkuk.kuit.durimong.domain.column.service.ColumnService;
 import konkuk.kuit.durimong.global.annotation.CustomExceptionDescription;
 import konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription;
@@ -11,15 +13,11 @@ import konkuk.kuit.durimong.global.exception.ErrorCode;
 import konkuk.kuit.durimong.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.COLUMN_CATEGORY;
-import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.COLUMN_VIEW;
+import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.*;
 
 @Slf4j
 @RestController
@@ -42,6 +40,14 @@ public class ColumnController {
     public SuccessResponse<CategoryDetailRes> getEachCategoryDetail(@PathVariable Long categoryId) {
 
         return SuccessResponse.ok(columnService.getCategoryDetail(categoryId));
+    }
+
+    @GetMapping("/search")
+    @Operation(summary = "칼럼 키워드 검색 결과", description = "키워드로 칼럼을 검색합니다.")
+    @CustomExceptionDescription(COLUMN_SEARCH)
+    public SuccessResponse<KeywordSearchRes> getKeywordSearchResult(@RequestParam @Parameter(description = "검색 키워드", example = "어려움") String keyword) {
+
+        return SuccessResponse.ok(columnService.searchColumnsByKeyword(keyword));
     }
 
     @GetMapping("/categories/{categoryId}")

--- a/src/main/java/konkuk/kuit/durimong/domain/column/controller/ColumnController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/controller/ColumnController.java
@@ -1,7 +1,9 @@
 package konkuk.kuit.durimong.domain.column.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import konkuk.kuit.durimong.domain.column.dto.response.CategoryDetailRes;
 import konkuk.kuit.durimong.domain.column.dto.response.CategoryRes;
+import konkuk.kuit.durimong.domain.column.dto.response.ColumnRes;
 import konkuk.kuit.durimong.domain.column.service.ColumnService;
 import konkuk.kuit.durimong.global.annotation.CustomExceptionDescription;
 import konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription;
@@ -10,12 +12,14 @@ import konkuk.kuit.durimong.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.COLUMN_CATEGORY;
+import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.COLUMN_VIEW;
 
 @Slf4j
 @RestController
@@ -30,6 +34,22 @@ public class ColumnController {
     public SuccessResponse<CategoryRes> getCategoryPage() {
 
         return SuccessResponse.ok(columnService.getAllCategories());
+    }
+
+    @GetMapping("/categories/{categoryId}/details")
+    @Operation(summary = "카테고리 상세설명 조회", description = "단일 카테고리 상세설명을 조회합니다.")
+    @CustomExceptionDescription(COLUMN_CATEGORY)
+    public SuccessResponse<CategoryDetailRes> getEachCategoryDetail(@PathVariable Long categoryId) {
+
+        return SuccessResponse.ok(columnService.getCategoryDetail(categoryId));
+    }
+
+    @GetMapping("/categories/{categoryId}")
+    @Operation(summary = "칼럼 조회", description = "각 칼럼을 조회합니다.")
+    @CustomExceptionDescription(COLUMN_VIEW)
+    public SuccessResponse<ColumnRes> getCategory(@PathVariable Long categoryId) {
+
+        return SuccessResponse.ok(columnService.viewColumn(categoryId));
     }
 
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/CategoryRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/CategoryRes.java
@@ -19,6 +19,9 @@ public class CategoryRes {
     @Builder
     @Schema(description = "단일 카테고리 DTO")
     public static class CategoryDTO {
+        @Schema(description = "카테고리 id", example = "1")
+        private Long categoryId;
+
         @Schema(description = "카테고리 이름", example = "수면장애")
         private String name;
 

--- a/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/ColumnRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/ColumnRes.java
@@ -25,4 +25,5 @@ public class ColumnRes {
     @Schema(description = "칼럼 이미지", example = "https://durimong.com/column/1/image.jpg")
     private String image;
 
+
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/KeywordSearchRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/KeywordSearchRes.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class KeywordSearchRes {
     @Schema(description = "검색 결과 칼럼 목록")
     private List<ColumnDTO> columns;
-
+    // DTO 변경하기
     @Data
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/KeywordSearchRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/KeywordSearchRes.java
@@ -22,6 +22,9 @@ public class KeywordSearchRes {
     @Builder
     @Schema(description = "단일 칼럼 DTO")
     public static class ColumnDTO {
+        @Schema(description = "카테고리 id", example = "1")
+        private Long categoryId;
+
         @Schema(description = "카테고리 이름", example = "불면증")
         private String categoryName;
 

--- a/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/KeywordSearchRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/dto/response/KeywordSearchRes.java
@@ -22,19 +22,10 @@ public class KeywordSearchRes {
     @Builder
     @Schema(description = "단일 칼럼 DTO")
     public static class ColumnDTO {
-        @Schema(description = "칼럼 id", example = "1")
-        private Long id;
+        @Schema(description = "카테고리 이름", example = "불면증")
+        private String categoryName;
 
-        @Schema(description = "카테고리 id", example = "1")
-        private Long categoryId;
-
-        @Schema(description = "칼럼 제목", example = "수면장애에 대한 이야기")
-        private String title;
-
-        @Schema(description = "미리보기(최대 50자)", example = "잠드는 데 어려움을 겪거나, 잠을 유지하는데...")
+        @Schema(description = "미리보기(~25자)", example = "잠드는 데 어려움을 겪거나, 잠을 유지하는데...")
         private String preview;
-
-        @Schema(description = "칼럼 이미지", example = "https://durimong.com/columns/images/sleep.jpg")
-        private String image;
     }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/repository/CategoryRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/repository/CategoryRepository.java
@@ -3,6 +3,8 @@ package konkuk.kuit.durimong.domain.column.repository;
 import konkuk.kuit.durimong.domain.column.entity.ColumnCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CategoryRepository extends JpaRepository<ColumnCategory, Long> {
+import java.util.Optional;
 
+public interface CategoryRepository extends JpaRepository<ColumnCategory, Long> {
+   // boolean findByName(String name);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/repository/ColumnRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/repository/ColumnRepository.java
@@ -2,9 +2,20 @@ package konkuk.kuit.durimong.domain.column.repository;
 
 import konkuk.kuit.durimong.domain.column.entity.Column;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ColumnRepository extends JpaRepository<Column, Long> {
     Optional<Column> findByCategory_CategoryId(Long categoryId);
+
+    // keyword에 해당하는 title -> subtitle -> content검색 (대소문자 구분 X)
+    @Query("SELECT c FROM Column c " +
+            "WHERE LOWER(c.title) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(c.subtitle) LIKE LOWER(CONCAT('%', :keyword, '%')) " +
+            "OR LOWER(c.content) LIKE LOWER(CONCAT('%', :keyword, '%'))")
+    List<Column> searchByKeyword(@Param("keyword") String keyword);
+
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/repository/ColumnRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/repository/ColumnRepository.java
@@ -3,6 +3,8 @@ package konkuk.kuit.durimong.domain.column.repository;
 import konkuk.kuit.durimong.domain.column.entity.Column;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ColumnRepository extends JpaRepository<Column, Long> {
+import java.util.Optional;
 
+public interface ColumnRepository extends JpaRepository<Column, Long> {
+    Optional<Column> findByCategory_CategoryId(Long categoryId);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import konkuk.kuit.durimong.domain.column.dto.response.CategoryDetailRes;
 import konkuk.kuit.durimong.domain.column.dto.response.CategoryRes;
 import konkuk.kuit.durimong.domain.column.dto.response.ColumnRes;
+import konkuk.kuit.durimong.domain.column.dto.response.KeywordSearchRes;
 import konkuk.kuit.durimong.domain.column.entity.Column;
 import konkuk.kuit.durimong.domain.column.entity.ColumnCategory;
 import konkuk.kuit.durimong.domain.column.repository.CategoryRepository;
@@ -12,6 +13,7 @@ import konkuk.kuit.durimong.global.exception.CustomException;
 import konkuk.kuit.durimong.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -47,9 +49,58 @@ public class ColumnService {
         return new CategoryDetailRes(category.getDetail());
     }
 
+    public KeywordSearchRes searchColumnsByKeyword(String keyword) {
+        // Column엔터티에서는 제목, 소제목, 내용 중 키워드 포함 찾기
+        // 결과가 있으면 포함하는 단어 혹은 문장 최대 25자 이내로 반환 + 그 칼럼의 카테고리 Id 참조하여 카테고리 이름
+        // 결과가 없으면... {keyword}에 대한 검색결과가 없다고 반환.
+
+        if(keyword == null || keyword.isEmpty()) {
+            throw new CustomException(ErrorCode.KEYWORD_NOT_EXISTS);
+        }
+
+        if(keyword.length()>10) {
+            throw new CustomException(ErrorCode.KEYWORD_LENGTH_OVER);
+        }
+
+        List<Column> resultColumns = columnRepository.searchByKeyword(keyword);
+
+        if(resultColumns.isEmpty()) {
+            throw new CustomException(ErrorCode.KEYWORD_RESULT_NOT_EXISTS);
+        }
+
+        List<KeywordSearchRes.ColumnDTO> columnList = resultColumns.stream()
+                .map(column -> new KeywordSearchRes.ColumnDTO(
+                        column.getCategory().getName(),
+                        extractPreview(column,keyword)
+                ))
+                .collect(Collectors.toList());
+
+        return new KeywordSearchRes(columnList);
+    }
+
+    public String extractPreview(Column column, String keyword) {
+        // 제목 -> 소제목 -> 내용 우선순위
+        String[] keywords = {column.getTitle(),column.getSubtitle(), column.getContent()};
+
+        for (String preview: keywords) {
+            if (preview != null && preview.contains(keyword)) {
+                // 키워드 포함 25자 이내로 자르기
+                // 25 - 키워드 길이 -> 키워드가 중간에 있도록
+                // 10자 - 키워드 15자 - 키워드 + 키워드 => 25자 - 키워드
+
+                int keywordIndex = preview.indexOf(keyword); // 키워드 발견위치
+                // 키워드가 양끝에 있을 가능성 고려하여 Math 함수 사용 (키워드 이전 10글자 ~ 키워드 이후 15글자)
+                int start = Math.max(0, keywordIndex - 10);
+                int end = Math.min(preview.length(), keywordIndex + keyword.length() + 15);
+                return preview.substring(start, end);
+            }
+        }
+        return null;
+    }
+
     public ColumnRes viewColumn(Long categoryId) {
         Column column = columnRepository.findByCategory_CategoryId(categoryId)
-                .orElseThrow(() -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.COLUMN_NOT_EXISTS));
 
         return new ColumnRes(
                 column.getCategory().getName(),

--- a/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
@@ -31,6 +31,7 @@ public class ColumnService {
     public CategoryRes getAllCategories() {
         List<CategoryRes.CategoryDTO> categoryList = categoryRepository.findAll().stream()
                 .map(category -> new CategoryRes.CategoryDTO(
+                        category.getCategoryId(),
                         category.getName(),
                         category.getImage()
                 ))

--- a/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
@@ -1,7 +1,11 @@
 package konkuk.kuit.durimong.domain.column.service;
 
 import jakarta.transaction.Transactional;
+import konkuk.kuit.durimong.domain.column.dto.response.CategoryDetailRes;
 import konkuk.kuit.durimong.domain.column.dto.response.CategoryRes;
+import konkuk.kuit.durimong.domain.column.dto.response.ColumnRes;
+import konkuk.kuit.durimong.domain.column.entity.Column;
+import konkuk.kuit.durimong.domain.column.entity.ColumnCategory;
 import konkuk.kuit.durimong.domain.column.repository.CategoryRepository;
 import konkuk.kuit.durimong.domain.column.repository.ColumnRepository;
 import konkuk.kuit.durimong.global.exception.CustomException;
@@ -11,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -34,5 +39,24 @@ public class ColumnService {
         }
 
         return new CategoryRes(categoryList);
+    }
+
+    public CategoryDetailRes getCategoryDetail(Long id) {
+        ColumnCategory category = categoryRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.COLUMN_CATEGORY_NOT_FOUND));
+
+        return new CategoryDetailRes(category.getDetail());
+    }
+
+    public ColumnRes viewColumn(Long categoryId) {
+        Column column = columnRepository.findByCategory_CategoryId(categoryId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
+
+        return new ColumnRes(
+                column.getCategory().getName(),
+                column.getTitle(),
+                column.getSubtitle(),
+                column.getContent(),
+                column.getImage()
+        );
     }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
@@ -70,6 +70,7 @@ public class ColumnService {
 
         List<KeywordSearchRes.ColumnDTO> columnList = resultColumns.stream()
                 .map(column -> new KeywordSearchRes.ColumnDTO(
+                        column.getCategory().getCategoryId(),
                         column.getCategory().getName(),
                         extractPreview(column,keyword)
                 ))

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -103,8 +103,13 @@ public enum SwaggerResponseDescription {
             COLUMN_CATEGORY_NOT_FOUND,
             COLUMN_CATEGORY_DETAIL_NOT_FOUND
     ))),
+    COLUMN_SEARCH(new LinkedHashSet<>(Set.of(
+            KEYWORD_NOT_EXISTS,
+            KEYWORD_LENGTH_OVER,
+            KEYWORD_RESULT_NOT_EXISTS
+    ))),
     COLUMN_VIEW(new LinkedHashSet<>(Set.of(
-            COLUMN_NOT_FOUND
+            COLUMN_NOT_EXISTS
     )));
 
 

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -100,7 +100,11 @@ public enum SwaggerResponseDescription {
 
     //COLUMN
     COLUMN_CATEGORY(new LinkedHashSet<>(Set.of(
-            COLUMN_CATEGORY_NOT_FOUND
+            COLUMN_CATEGORY_NOT_FOUND,
+            COLUMN_CATEGORY_DETAIL_NOT_FOUND
+    ))),
+    COLUMN_VIEW(new LinkedHashSet<>(Set.of(
+            COLUMN_NOT_FOUND
     )));
 
 

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -58,7 +58,9 @@ public enum ErrorCode {
     //UserMongConversation
     CONVERSATION_NOT_EXISTS(-500,"몽과의 대화가 존재하지 않습니다,",404),
     //Column
-    COLUMN_CATEGORY_NOT_FOUND(-500, "등록된 카테고리가 없습니다",404);
+    COLUMN_CATEGORY_NOT_FOUND(-600, "등록된 카테고리가 없습니다",404),
+    COLUMN_CATEGORY_DETAIL_NOT_FOUND(-601, "등록된 카테고리 설명이 없습니다", 404),
+    COLUMN_NOT_FOUND(-602,"등록된 칼럼이 없습니다.", 404);
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -60,7 +60,10 @@ public enum ErrorCode {
     //Column
     COLUMN_CATEGORY_NOT_FOUND(-600, "등록된 카테고리가 없습니다",404),
     COLUMN_CATEGORY_DETAIL_NOT_FOUND(-601, "등록된 카테고리 설명이 없습니다", 404),
-    COLUMN_NOT_FOUND(-602,"등록된 칼럼이 없습니다.", 404);
+    COLUMN_NOT_EXISTS(-602,"등록된 칼럼이 없습니다.", 404),
+    KEYWORD_NOT_EXISTS(-603,"키워드가 존재하지 않습니다.", 404),
+    KEYWORD_LENGTH_OVER(-604, "키워드 길이는 10자 이내여야 합니다.", 400),
+    KEYWORD_RESULT_NOT_EXISTS(-605,"키워드에 해당하는 내용이 없습니다", 404);
 
     private final int errorCode;
     private final String message;


### PR DESCRIPTION
## 📝작업 내용
카테고리 상세정보 조회 : 카테고리의 ? 버튼을 눌렀을때 상세정보를 반환합니다.
키워드 검색 : 10자 이내의 키워드를 검색했을때 해당 키워드를 포함하여 25자 이내의 문구와 해당 칼럼의 카테고리 명을 반환합니다. 
칼럼 조회 : 카테고리 내부에 있는 칼럼을 선택하면 카테고리 이름, 제목, 소제목, 내용, 이미지 정보를 반환합니다.

추가로 ErrorCode 클래스에서 Column에 관한 에러들이 UserMongConversation과 같은 -500번대의 에러코드였는데 (지난 PR에서 merge 과정 중 실수) -600번대 에러코드로 전부 수정하였습니다.
## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
