### PR TITLE
Feat: Test 상세정보 조회 기능 구현

### DIFF
--- a/src/main/java/konkuk/kuit/durimong/domain/activity/service/ActivityService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/activity/service/ActivityService.java
@@ -64,7 +64,7 @@ public class ActivityService {
                 .toList();
 
         if(activityList.isEmpty() ){
-            throw new CustomException(ErrorCode.ACTIVITY_NOT_FOUND);
+            throw new CustomException(ErrorCode.ACTIVITY_NOT_EXSITS);
         }
 
         List<ActivityTestListRes.TestListDTO> testList = testRepository.findAll().stream()
@@ -84,7 +84,7 @@ public class ActivityService {
     // 활동 설명화면 조회
     public Object getActivityDetails(Long activityId) {
         Activity activity = activityRepository.findById(activityId)
-                .orElseThrow(() -> new CustomException(ErrorCode.ACTIVITY_ID_NOT_EXISTS));
+                .orElseThrow(() -> new CustomException(ErrorCode.ACTIVITY_NOT_FOUND));
 
         boolean hasBoxes = activityBoxRepository.existsByActivity(activity);
 
@@ -115,7 +115,7 @@ public class ActivityService {
     // 활동 체크
     public void makeUserRecord(CheckActivityReq req, Long userId) {
         Activity activity = activityRepository.findById(req.getActivityId())
-                .orElseThrow(() -> new CustomException(ErrorCode.ACTIVITY_ID_NOT_EXISTS));
+                .orElseThrow(() -> new CustomException(ErrorCode.ACTIVITY_NOT_FOUND));
 
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/konkuk/kuit/durimong/domain/column/controller/ColumnController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/controller/ColumnController.java
@@ -36,7 +36,7 @@ public class ColumnController {
 
     @GetMapping("/categories/{categoryId}/details")
     @Operation(summary = "카테고리 상세설명 조회", description = "단일 카테고리 상세설명을 조회합니다.")
-    @CustomExceptionDescription(COLUMN_CATEGORY)
+    @CustomExceptionDescription(COLUMN_CATEGORY_DETAIL)
     public SuccessResponse<CategoryDetailRes> getEachCategoryDetail(@PathVariable Long categoryId) {
 
         return SuccessResponse.ok(columnService.getCategoryDetail(categoryId));

--- a/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/column/service/ColumnService.java
@@ -38,16 +38,22 @@ public class ColumnService {
                 .collect(Collectors.toList());
 
         if (categoryList.isEmpty()) {
-            throw new CustomException(ErrorCode.COLUMN_CATEGORY_NOT_FOUND);
+            throw new CustomException(ErrorCode.COLUMN_CATEGORY_NOT_EXISTS);
         }
 
         return new CategoryRes(categoryList);
     }
 
     public CategoryDetailRes getCategoryDetail(Long id) {
-        ColumnCategory category = categoryRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.COLUMN_CATEGORY_NOT_FOUND));
+        ColumnCategory category = categoryRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.COLUMN_CATEGORY_NOT_EXISTS));
 
-        return new CategoryDetailRes(category.getDetail());
+        String categoryDetail = category.getDetail();
+
+        if (categoryDetail == null || categoryDetail.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.COLUMN_CATEGORY_DETAIL_NOT_EXISTS);
+        }
+
+        return new CategoryDetailRes(categoryDetail);
     }
 
     public KeywordSearchRes searchColumnsByKeyword(String keyword) {
@@ -66,7 +72,7 @@ public class ColumnService {
         List<Column> resultColumns = columnRepository.searchByKeyword(keyword);
 
         if(resultColumns.isEmpty()) {
-            throw new CustomException(ErrorCode.KEYWORD_RESULT_NOT_EXISTS);
+            throw new CustomException(ErrorCode.KEYWORD_RESULT_NOT_FOUND);
         }
 
         List<KeywordSearchRes.ColumnDTO> columnList = resultColumns.stream()
@@ -102,7 +108,7 @@ public class ColumnService {
 
     public ColumnRes viewColumn(Long categoryId) {
         Column column = columnRepository.findByCategory_CategoryId(categoryId)
-                .orElseThrow(() -> new CustomException(ErrorCode.COLUMN_NOT_EXISTS));
+                .orElseThrow(() -> new CustomException(ErrorCode.COLUMN_NOT_FOUND));
 
         return new ColumnRes(
                 column.getCategory().getName(),

--- a/src/main/java/konkuk/kuit/durimong/domain/test/Enum/TestResponseOption.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/Enum/TestResponseOption.java
@@ -1,0 +1,40 @@
+package konkuk.kuit.durimong.domain.test.Enum;
+
+import konkuk.kuit.durimong.global.exception.CustomException;
+import konkuk.kuit.durimong.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+public enum TestResponseOption {
+    // 스트레스 검사
+    STRESS_SCORE_ONE(3, 1, "그렇지 않다"),
+    STRESS_SCORE_TWO(3, 2, "보통이다"),
+    STRESS_SCORE_THREE(3, 3, "매우 그렇다");
+    // 우울증 검사
+
+    private final int testId;
+    private final int score;
+    private final String response;
+
+    public static String getMinResponse(int testId) {
+        return Arrays.stream(values())
+                .filter(option -> option.getTestId() == testId)
+                .min(Comparator.comparingInt(TestResponseOption::getScore))
+                .map(TestResponseOption::getResponse)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEST_MIN_RESPONSE_NOT_EXISTS));
+    }
+
+    public static String getMaxResponse(int testId) {
+        return Arrays.stream(values())
+                .filter(option -> option.getTestId() == testId)
+                .max(Comparator.comparingInt(TestResponseOption::getScore))
+                .map(TestResponseOption::getResponse)
+                .orElseThrow(() -> new CustomException(ErrorCode.TEST_MAX_RESPONSE_NOT_EXISTS));
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/controller/TestController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/controller/TestController.java
@@ -1,4 +1,34 @@
 package konkuk.kuit.durimong.domain.test.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import konkuk.kuit.durimong.domain.test.dto.response.TestDescriptionRes;
+import konkuk.kuit.durimong.domain.test.service.TestService;
+import konkuk.kuit.durimong.global.annotation.CustomExceptionDescription;
+import konkuk.kuit.durimong.global.annotation.UserId;
+import konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription;
+import konkuk.kuit.durimong.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static konkuk.kuit.durimong.global.config.swagger.SwaggerResponseDescription.TEST_DESCRIPTION;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("tests")
 public class TestController {
+    private final TestService testService;
+
+    @GetMapping("/{testId}")
+    @Operation(summary = "테스트 상세정보 조회", description = "testId에 해당하는 테스트 정보와 유저의 직전 검사 기록을 확인합니다.")
+    @CustomExceptionDescription(TEST_DESCRIPTION)
+    public SuccessResponse<TestDescriptionRes> viewTestInfo(@PathVariable Long testId, @Parameter(hidden = true) @UserId Long userId) {
+
+        return SuccessResponse.ok(testService.getTestDescription(testId, userId));
+    }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/test/controller/TestController.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/controller/TestController.java
@@ -1,0 +1,4 @@
+package konkuk.kuit.durimong.domain.test.controller;
+
+public class TestController {
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/dto/request/SubmitTestReq.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/dto/request/SubmitTestReq.java
@@ -1,0 +1,30 @@
+package konkuk.kuit.durimong.domain.test.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "테스트 완료 RequestDTO")
+public class SubmitTestReq {
+    @Schema(description = "유저의 응답 리스트")
+    private List<UserResponseDTO> responseList;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "유저의 응답 리스트 DTO")
+    public static class UserResponseDTO {
+        @Schema(description = "문항 번호", example = "1")
+        private Integer number;
+
+        @Schema(description = "유저의 선택", example = "1")
+        private Integer choice;
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/DoTestRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/DoTestRes.java
@@ -1,0 +1,42 @@
+package konkuk.kuit.durimong.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "테스트 검사 시작 ResponseDTO")
+public class DoTestRes {
+    @Schema(description = "테스트 id", example = "1")
+    private Long testId;
+
+    @Schema(description = "테스트 이름", example = "스트레스 수치 검사")
+    private String testName;
+
+    @Schema(description = "문항 수", example = "11")
+    private int numberOfQuestions;
+
+    @Schema(description = "선택지 개수", example = "3")
+    private int numberOfOptions;
+
+    @Schema(description = "질문 리스트")
+    private List<QuestionListDTO> questionList;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "단일 활동 DTO")
+    public static class QuestionListDTO {
+        @Schema(description = "번호", example = "1")
+        private Long activityId;
+
+        @Schema(description = "문항", example = "쉽게 짜증이 나고 기분의 변동이 심하다.")
+        private String question;
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/SubmitTestRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/SubmitTestRes.java
@@ -12,9 +12,6 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 public class SubmitTestRes {
-    @Schema(description = "테스트 ID", example = "1")
-    private int testId;
-
     @Schema(description = "테스트 이름", example = "스트레스 수치 검사")
     private String testName;
 

--- a/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/SubmitTestRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/SubmitTestRes.java
@@ -1,0 +1,61 @@
+package konkuk.kuit.durimong.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.kuit.durimong.domain.test.entity.ScoreDistribution;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class SubmitTestRes {
+    @Schema(description = "테스트 ID", example = "1")
+    private int testId;
+
+    @Schema(description = "테스트 이름", example = "스트레스 수치 검사")
+    private String testName;
+
+    @Schema(description = "사용자 이름", example = "엘리자베스")
+    private String userName;
+
+    @Schema(description = "사용자의 테스트 점수", example = "15")
+    private int userScore;
+
+    @Schema(description = "사용자의 스트레스 검사 결과")
+    private UserResult userResult;
+
+    @Schema(description = "점수 분포 정보 리스트")
+    private List<ScoreDistribution> scoreDistribution;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "사용자의 스트레스 검사 결과 DTO")
+    public static class UserResult {
+        @Schema(description = "해당 점수 범위", example = "14-16")
+        private String scoreRange;
+
+        @Schema(description = "사용자의 스트레스 수준 설명", example = "스트레스 지수 40% 비교적 심한 스트레스")
+        private String description;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "스트레스 점수 분포 DTO")
+    public static class ScoreDistribution {
+        @Schema(description = "최소 점수", example = "14")
+        private int minScore;
+
+        @Schema(description = "최대 점수", example = "16(nullable)")
+        private Integer maxScore;
+
+        @Schema(description = "해당 점수의 스트레스 설명", example = "스트레스 지수 40% (비교적 심한 스트레스)")
+        private String description;
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/TestDescriptionRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/TestDescriptionRes.java
@@ -1,0 +1,83 @@
+package konkuk.kuit.durimong.domain.test.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "테스트 설명 ResponseDTO")
+public class TestDescriptionRes {
+    @Schema(description = "테스트 id", example = "1")
+    private Long testId;
+
+    @Schema(description = "테스트 이름", example = "스트레스 수치 검사")
+    private String testName;
+
+    @Schema(description = "테스트 영문 이름", example = "BEPSI")
+    private String testEnglishName;
+
+    @Schema(description = "테스트 내용", example = "지난 한 달 동안의...")
+    private String content;
+
+    @Schema(description = "최소 선택지 번호", example = "1")
+    private int minNumber;
+
+    @Schema(description = "최소 선택지 문구", example = "그렇지 않다")
+    private String  minOption;
+
+    @Schema(description = "최대 선택지 번호", example = "3")
+    private int maxNumber;
+
+    @Schema(description = "최대 선택지 문구", example = "매우 그렇다")
+    private String  maxOption;
+
+    @Schema(description = "임계 점수", example = "22")
+    private int criticalScore;
+
+    @Schema(description = "문항 수 / 소요시간 리스트", example = "5 ~ 10문항 / 5 ~ 10분")
+    private List<QuestionAndTimeListDTO> questionAndTimeList;
+
+    @Schema(description = "직전 검사 기록")
+    private List<LastTestListDTO> lastTestInfo;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "문항 수 / 소요시간 DTO")
+    public static class QuestionAndTimeListDTO {
+        @Schema(description = "최소 문항 수", example = "11")
+        private int minQuestion;
+
+        @Schema(description = "최대 문항 수", example = "20 (nullable")
+        private Integer maxQuestion;
+
+        @Schema(description = "최소 소요시간", example = "3")
+        private int minTime;
+
+        @Schema(description = "최대 소요시간", example = "5 (nullable")
+        private Integer maxTime;
+    }
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @Schema(description = "직전 테스트 결과 DTO")
+    public static class LastTestListDTO {
+        @Schema(description = "직전 검사 날짜", example = "2025-02-06")
+        private LocalDate date;
+
+        @Schema(description = "유저 닉네임", example = "엘리자베스")
+        private String userName;
+
+        @Schema(description = "직전 테스트 점수", example = "15")
+        private int lastScore;
+    }
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/TestDescriptionRes.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/dto/response/TestDescriptionRes.java
@@ -29,48 +29,32 @@ public class TestDescriptionRes {
     private int minNumber;
 
     @Schema(description = "최소 선택지 문구", example = "그렇지 않다")
-    private String  minOption;
+    private String  minOptionResponse;
 
     @Schema(description = "최대 선택지 번호", example = "3")
     private int maxNumber;
 
     @Schema(description = "최대 선택지 문구", example = "매우 그렇다")
-    private String  maxOption;
+    private String  maxOptionResponse;
 
     @Schema(description = "임계 점수", example = "22")
     private int criticalScore;
 
-    @Schema(description = "문항 수 / 소요시간 리스트", example = "5 ~ 10문항 / 5 ~ 10분")
-    private List<QuestionAndTimeListDTO> questionAndTimeList;
+    @Schema(description = "문항 수", example = "11")
+    private int countOfQuestions;
 
-    @Schema(description = "직전 검사 기록")
-    private List<LastTestListDTO> lastTestInfo;
+    @Schema(description = "소요시간", example = "5")
+    private int requiredTime;
 
-    @Data
-    @NoArgsConstructor
-    @AllArgsConstructor
-    @Builder
-    @Schema(description = "문항 수 / 소요시간 DTO")
-    public static class QuestionAndTimeListDTO {
-        @Schema(description = "최소 문항 수", example = "11")
-        private int minQuestion;
-
-        @Schema(description = "최대 문항 수", example = "20 (nullable")
-        private Integer maxQuestion;
-
-        @Schema(description = "최소 소요시간", example = "3")
-        private int minTime;
-
-        @Schema(description = "최대 소요시간", example = "5 (nullable")
-        private Integer maxTime;
-    }
+    @Schema(description = "직전 테스트 결과 정보")
+    private LastTestDTO lastTestDTO;
 
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     @Builder
     @Schema(description = "직전 테스트 결과 DTO")
-    public static class LastTestListDTO {
+    public static class LastTestDTO {
         @Schema(description = "직전 검사 날짜", example = "2025-02-06")
         private LocalDate date;
 
@@ -78,6 +62,6 @@ public class TestDescriptionRes {
         private String userName;
 
         @Schema(description = "직전 테스트 점수", example = "15")
-        private int lastScore;
+        private Integer lastScore;
     }
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/test/entity/ScoreDistribution.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/entity/ScoreDistribution.java
@@ -1,0 +1,31 @@
+package konkuk.kuit.durimong.domain.test.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "score_distribution")
+public class ScoreDistribution {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "score_distribution")
+    private Long scoreDistributionId;
+
+    @Column(name = "start_score", nullable = false)
+    private int startScore;
+
+    @Column(name = "end_score", nullable = false)
+    private int endScore;
+
+    @Column(nullable = false)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id", nullable = false)
+    private Test test;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/entity/ScoreDistribution.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/entity/ScoreDistribution.java
@@ -13,7 +13,7 @@ import lombok.*;
 public class ScoreDistribution {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "score_distribution")
+    @Column(name = "score_distribution_id")
     private Long scoreDistributionId;
 
     @Column(name = "start_score", nullable = false)

--- a/src/main/java/konkuk/kuit/durimong/domain/test/entity/Test.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/entity/Test.java
@@ -25,17 +25,17 @@ public class Test {
     @Column(nullable = false, length = 500)
     private String content;
 
-    @Column(nullable = false)
-    private String number;
+    @Column(name = "count_of_questions", nullable = false)
+    private int countOfQuestions;
 
     @Column(name = "required_time", nullable = false)
-    private String requiredTime;
+    private int requiredTime;
 
-    @Column(name = "min_option", nullable = false)
-    private Integer minOption;
+    @Column(name = "min_number", nullable = false)
+    private Integer minNumber;
 
-    @Column(name = "max_option", nullable = false)
-    private Integer maxOption;
+    @Column(name = "max_number", nullable = false)
+    private Integer maxNumber;
 
     @Column(name = "critical_score", nullable = false)
     private Integer criticalScore;

--- a/src/main/java/konkuk/kuit/durimong/domain/test/entity/TestContent.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/entity/TestContent.java
@@ -1,0 +1,28 @@
+package konkuk.kuit.durimong.domain.test.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "test_content")
+public class TestContent {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "test_content_id")
+    private Long testContentId;
+
+    @Column(nullable = false)
+    private int number;
+
+    @Column(nullable = false)
+    private String question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id", nullable = false)
+    private Test test;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/entity/UserTest.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/entity/UserTest.java
@@ -1,0 +1,35 @@
+package konkuk.kuit.durimong.domain.test.entity;
+
+import jakarta.persistence.*;
+import konkuk.kuit.durimong.domain.user.entity.User;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "user_test")
+public class UserTest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_test_id")
+    private Long userTestId;
+
+    @Column(nullable = false)
+    private int score;
+
+    @Column(name = "createdAt", nullable = false)
+    private LocalDate createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "test_id", nullable = false)
+    private Test test;
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/repository/ScoreDistributionRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/repository/ScoreDistributionRepository.java
@@ -1,0 +1,7 @@
+package konkuk.kuit.durimong.domain.test.repository;
+
+import konkuk.kuit.durimong.domain.test.entity.ScoreDistribution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScoreDistributionRepository extends JpaRepository<ScoreDistribution, Long> {
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/repository/TestContentRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/repository/TestContentRepository.java
@@ -1,0 +1,7 @@
+package konkuk.kuit.durimong.domain.test.repository;
+
+import konkuk.kuit.durimong.domain.test.entity.TestContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TestContentRepository extends JpaRepository<TestContent, Long> {
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/repository/UserTestRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/repository/UserTestRepository.java
@@ -1,0 +1,7 @@
+package konkuk.kuit.durimong.domain.test.repository;
+
+import konkuk.kuit.durimong.domain.test.entity.UserTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserTestRepository extends JpaRepository<UserTest, Long> {
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/repository/UserTestRepository.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/repository/UserTestRepository.java
@@ -1,7 +1,13 @@
 package konkuk.kuit.durimong.domain.test.repository;
 
+import konkuk.kuit.durimong.domain.test.entity.Test;
 import konkuk.kuit.durimong.domain.test.entity.UserTest;
+import konkuk.kuit.durimong.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface UserTestRepository extends JpaRepository<UserTest, Long> {
+    Optional<UserTest> findFirstByUserAndTestOrderByCreatedAtDesc(User user, Test test);
 }

--- a/src/main/java/konkuk/kuit/durimong/domain/test/service/TestService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/service/TestService.java
@@ -1,0 +1,4 @@
+package konkuk.kuit.durimong.domain.test.service;
+
+public class TestService {
+}

--- a/src/main/java/konkuk/kuit/durimong/domain/test/service/TestService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/service/TestService.java
@@ -38,7 +38,7 @@ public class TestService {
         String nickname = user.getNickname();
 
         Test test = testRepository.findById(testId)
-                        .orElseThrow(() -> new CustomException(ErrorCode.TEST_ID_NOT_EXISTS));
+                        .orElseThrow(() -> new CustomException(ErrorCode.TEST_NOT_FOUND));
 
         // userTest에서 직전 검사 결과 가져오기 (직전 날짜, 직전 점수)
         Optional<UserTest> userTestOptional = userTestRepository.findFirstByUserAndTestOrderByCreatedAtDesc(user, test);

--- a/src/main/java/konkuk/kuit/durimong/domain/test/service/TestService.java
+++ b/src/main/java/konkuk/kuit/durimong/domain/test/service/TestService.java
@@ -1,4 +1,59 @@
 package konkuk.kuit.durimong.domain.test.service;
 
+import konkuk.kuit.durimong.domain.test.Enum.TestResponseOption;
+import konkuk.kuit.durimong.domain.test.dto.response.TestDescriptionRes;
+import konkuk.kuit.durimong.domain.test.entity.Test;
+import konkuk.kuit.durimong.domain.test.entity.UserTest;
+import konkuk.kuit.durimong.domain.test.repository.ScoreDistributionRepository;
+import konkuk.kuit.durimong.domain.test.repository.TestContentRepository;
+import konkuk.kuit.durimong.domain.test.repository.TestRepository;
+import konkuk.kuit.durimong.domain.test.repository.UserTestRepository;
+import konkuk.kuit.durimong.domain.user.entity.User;
+import konkuk.kuit.durimong.domain.user.repository.UserRepository;
+import konkuk.kuit.durimong.global.exception.CustomException;
+import konkuk.kuit.durimong.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
 public class TestService {
+    private final TestRepository testRepository;
+    private final UserTestRepository userTestRepository;
+    private final TestContentRepository testContentRepository;
+    private final ScoreDistributionRepository scoreDistributionRepository;
+    private final UserRepository userRepository;
+
+    // 테스트 상세정보 조회
+    public TestDescriptionRes getTestDescription(Long testId, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        String nickname = user.getNickname();
+
+        Test test = testRepository.findById(testId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.TEST_ID_NOT_EXISTS));
+
+        // userTest에서 직전 검사 결과 가져오기 (직전 날짜, 직전 점수)
+        Optional<UserTest> userTestOptional = userTestRepository.findFirstByUserAndTestOrderByCreatedAtDesc(user, test);
+
+        TestDescriptionRes.LastTestDTO lastTestInfo = userTestOptional
+                .map(userTest -> new TestDescriptionRes.LastTestDTO(userTest.getCreatedAt(), nickname, userTest.getScore()))
+                .orElse(new TestDescriptionRes.LastTestDTO(null, nickname, null));
+
+        // test엔터티의 minNumber와 maxNumber가 각각 같은지 확인
+
+        return new TestDescriptionRes(
+                testId, test.getName(), test.getEnglishName(),
+                test.getContent(), test.getMinNumber(),TestResponseOption.getMinResponse(testId.intValue()),
+                test.getMaxNumber(), TestResponseOption.getMaxResponse(testId.intValue()),test.getCriticalScore(),
+                test.getCountOfQuestions(), test.getRequiredTime(), lastTestInfo);
+    }
+
 }

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -157,6 +157,10 @@ public enum SwaggerResponseDescription {
             USER_NOT_FOUND,
             MONG_NOT_FOUND,
             USER_RECORD_DATE_NOT_VALID
+    ))),
+    // Test
+    TEST_DESCRIPTION(new LinkedHashSet<>(Set.of(
+            TEST_ID_NOT_EXISTS
     )));
 
     private Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/kuit/durimong/global/config/swagger/SwaggerResponseDescription.java
@@ -100,16 +100,19 @@ public enum SwaggerResponseDescription {
 
     //COLUMN
     COLUMN_CATEGORY(new LinkedHashSet<>(Set.of(
-            COLUMN_CATEGORY_NOT_FOUND,
-            COLUMN_CATEGORY_DETAIL_NOT_FOUND
+            COLUMN_CATEGORY_NOT_EXISTS
+    ))),
+    COLUMN_CATEGORY_DETAIL(new LinkedHashSet<>(Set.of(
+            COLUMN_CATEGORY_NOT_EXISTS,
+            COLUMN_CATEGORY_DETAIL_NOT_EXISTS
     ))),
     COLUMN_SEARCH(new LinkedHashSet<>(Set.of(
             KEYWORD_NOT_EXISTS,
             KEYWORD_LENGTH_OVER,
-            KEYWORD_RESULT_NOT_EXISTS
+            KEYWORD_RESULT_NOT_FOUND
     ))),
     COLUMN_VIEW(new LinkedHashSet<>(Set.of(
-            COLUMN_NOT_EXISTS
+            COLUMN_NOT_FOUND
     ))),
     CHAT_BOT(new LinkedHashSet<>(Set.of(
             CHATBOT_NOT_EXISTS
@@ -128,13 +131,13 @@ public enum SwaggerResponseDescription {
 
     //ACTIVITY
     ACTIVITY_TEST_LIST(new LinkedHashSet<>(Set.of(
-            ACTIVITY_NOT_FOUND,
-            TEST_NOT_FOUND,
+            ACTIVITY_NOT_EXSITS,
+            TEST_NOT_EXISTS,
             USER_NOT_FOUND,
             MONG_NOT_FOUND
     ))),
     ACTIVITY_EXIST(new LinkedHashSet<>(Set.of(
-            ACTIVITY_ID_NOT_EXISTS,
+            ACTIVITY_NOT_FOUND,
             USER_NOT_FOUND,
             ACTIVITY_ALREADY_CHECKED
     ))),
@@ -160,7 +163,8 @@ public enum SwaggerResponseDescription {
     ))),
     // Test
     TEST_DESCRIPTION(new LinkedHashSet<>(Set.of(
-            TEST_ID_NOT_EXISTS
+            TEST_NOT_FOUND,
+            USER_NOT_FOUND
     )));
 
     private Set<ErrorCode> errorCodeList;

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -84,7 +84,10 @@ public enum ErrorCode {
     USER_RECORD_EXISTS_OVER(-901, "완료한 활동 개수가 전체보다 많습니다", 400),
     USER_RECORD_DATE_NOT_VALID(-902, "유저 기록을 조회할 수 없는 기간입니다.", 404),
     //Test
-    TEST_NOT_FOUND(-1000,"등록된 테스트가 없습니다", 404);
+    TEST_NOT_FOUND(-1000,"등록된 테스트가 없습니다", 404),
+    TEST_ID_NOT_EXISTS(-1001, "해당 id의 테스트가 존재하지 않습니다", 404),
+    TEST_MIN_RESPONSE_NOT_EXISTS(-1002, "해당 테스트의 최소 점수 응답을 찾을 수 없습니다", 404),
+    TEST_MAX_RESPONSE_NOT_EXISTS(-1003, "해당 테스트의 최고 점수 응답을 찾을 수 없습니다", 404);
 
     private final int errorCode;
     private final String message;

--- a/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
+++ b/src/main/java/konkuk/kuit/durimong/global/exception/ErrorCode.java
@@ -58,12 +58,12 @@ public enum ErrorCode {
     //UserMongConversation
     CONVERSATION_NOT_EXISTS(-500,"몽과의 대화가 존재하지 않습니다,",404),
     //Column
-    COLUMN_CATEGORY_NOT_FOUND(-600, "등록된 카테고리가 없습니다",404),
-    COLUMN_CATEGORY_DETAIL_NOT_FOUND(-601, "등록된 카테고리 설명이 없습니다", 404),
-    COLUMN_NOT_EXISTS(-602,"등록된 칼럼이 없습니다.", 404),
+    COLUMN_CATEGORY_NOT_EXISTS(-600, "등록된 카테고리가 없습니다",404),
+    COLUMN_CATEGORY_DETAIL_NOT_EXISTS(-601, "등록된 카테고리 설명이 없습니다", 404),
+    COLUMN_NOT_FOUND(-602,"해당 id의 칼럼이 없습니다.", 404),
     KEYWORD_NOT_EXISTS(-603,"키워드가 존재하지 않습니다.", 404),
     KEYWORD_LENGTH_OVER(-604, "키워드 길이는 10자 이내여야 합니다.", 400),
-    KEYWORD_RESULT_NOT_EXISTS(-605,"키워드에 해당하는 내용이 없습니다", 404),
+    KEYWORD_RESULT_NOT_FOUND(-605,"키워드에 해당하는 내용이 없습니다", 404),
     //ChatBot
     CHATBOT_NOT_EXISTS(-700,"등록된 채팅봇이 없습니다.",404),
     CHATBOT_NOT_FOUND(-701,"존재하지 않는 채팅봇입니다.",404),
@@ -71,21 +71,21 @@ public enum ErrorCode {
     CHATBOT_SYMPOMS_EMPTY(-703,"선택된 증상이 없습니다.",422),
     CHATBOT_PREDICT_ERROR(-704,"GPT의 응답에서 질환을 추출하지 못했습니다.",404),
     //Activity
-    ACTIVITY_NOT_FOUND(-800, "등록된 활동이 없습니다", 404),
+    ACTIVITY_NOT_EXSITS(-800, "등록된 활동이 없습니다", 404),
     ACTIVITY_INVALID_STATUS(-801, "활동이 유효한 상태가 아닙니다", 400),
     ACTIVITY_USER_RECORD_NOT_FOUND(-802, "사용자의 활동 기록이 없습니다", 404),
     ACTIVITY_USER_RECORD_EXISTS_OVER(-803, "완료한 활동 개수가 전체보다 많습니다", 400),
     ACTIVITY_SAME_NAME(-804, "활동 이름이 중복됩니다", 409),
     ACTIVITY_PERMISSION_DENIED(-805, "활동을 수정 할 권한이 없습니다", 403),
-    ACTIVITY_ID_NOT_EXISTS(-806,"해당 id의 활동이 존재하지 않습니다",404),
+    ACTIVITY_NOT_FOUND(-806,"해당 id의 활동이 존재하지 않습니다",404),
     ACTIVITY_ALREADY_CHECKED(-807, "해당 날짜에 이미 완료한 활동입니다", 409),
     //UserRecord
     USER_RECORD_NOT_FOUND(-900, "유저의 활동 기록이 없습니다", 404),
     USER_RECORD_EXISTS_OVER(-901, "완료한 활동 개수가 전체보다 많습니다", 400),
     USER_RECORD_DATE_NOT_VALID(-902, "유저 기록을 조회할 수 없는 기간입니다.", 404),
     //Test
-    TEST_NOT_FOUND(-1000,"등록된 테스트가 없습니다", 404),
-    TEST_ID_NOT_EXISTS(-1001, "해당 id의 테스트가 존재하지 않습니다", 404),
+    TEST_NOT_EXISTS(-1000,"등록된 테스트가 없습니다", 404),
+    TEST_NOT_FOUND(-1001, "해당 id의 테스트가 존재하지 않습니다", 404),
     TEST_MIN_RESPONSE_NOT_EXISTS(-1002, "해당 테스트의 최소 점수 응답을 찾을 수 없습니다", 404),
     TEST_MAX_RESPONSE_NOT_EXISTS(-1003, "해당 테스트의 최고 점수 응답을 찾을 수 없습니다", 404);
 


### PR DESCRIPTION
## 📝작업 내용
Test 상세 정보 조회 기능을 구현했습니다.
테스트 별 응답 문항을 Enum으로 만들어서 처리했고, 각 테스트 별로 직전 검사 기록 (날짜, 유저 닉네임, 점수)까지 볼 수 있게 구현했습니다.
PM님께 제안한 결과, 문항 수는 범위가 아니라 정확한 문항수가 제공 될 예정이고 소요시간 도 약 N분의 형식으로 통일 되기로 해서 그에 맞춰 구현했습니다.
## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
